### PR TITLE
Add templates gemma and mistral

### DIFF
--- a/templates/Gemma-3-12b/README.md
+++ b/templates/Gemma-3-12b/README.md
@@ -1,0 +1,35 @@
+# Gemma 3 12B
+
+Google's Gemma 3 12B instruction-tuned model served via vLLM with an OpenAI-compatible API endpoint.
+
+## Key Features
+- High-performance inference with vLLM
+- OpenAI-compatible API
+- 12B parameter model with 34k context length
+- Instruction-tuned for better responses
+- Optimized for GPU acceleration
+
+## Configuration
+- Port: 9000
+- GPU: Required (60GB+ VRAM)
+- Model: google/gemma-3-12b-it
+- Context Length: 428,000 tokens
+
+## Usage
+You can interact with the model using the OpenAI API format:
+```python
+import openai
+
+client = openai.Client(
+    base_url="http://localhost:9000/v1"
+)
+
+response = client.chat.completions.create(
+    model="Gemma-3-12b",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me about Gemma 3."}
+    ]
+)
+print(response.choices[0].message.content)
+``` 

--- a/templates/Gemma-3-12b/info.json
+++ b/templates/Gemma-3-12b/info.json
@@ -1,0 +1,7 @@
+{
+  "id": "gem12b",
+  "name": "Gemma 3 12B",
+  "description": "Google's Gemma 3 12B instruction-tuned model served via vLLM with OpenAI-compatible API",
+  "category": ["API", "LLM", "New"],
+  "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c12/Google_%22G%22_logo.svg/768px-Google_%22G%22_logo.svg.png"
+} 

--- a/templates/Gemma-3-12b/job-definition.json
+++ b/templates/Gemma-3-12b/job-definition.json
@@ -1,0 +1,30 @@
+{
+  "ops": [
+    {
+      "id": "gem12b",
+      "args": {
+        "cmd": [
+          "/bin/sh",
+          "-c",
+          "python3 -m vllm.entrypoints.openai.api_server --model google/gemma-3-12b-it --served-model-name Gemma-3-12b --port 9000 --max-model-len 10000"
+        ],
+        "env": {
+          "HF_TOKEN": "fill_in_your_huggingface_token"
+        },
+        "gpu": true,
+        "image": "nosana/vllm:0.0.0",
+        "expose": 9000,
+        "entrypoint": []
+      },
+      "type": "container/run"
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "required_vram": 60
+    }
+  },
+  "type": "container",
+  "version": "0.1"
+}

--- a/templates/Gemma-3-1b /README.md
+++ b/templates/Gemma-3-1b /README.md
@@ -1,0 +1,35 @@
+# Gemma 3 1B
+
+Google's Gemma 3 1B instruction-tuned model served via vLLM with an OpenAI-compatible API endpoint.
+
+## Key Features
+- High-performance inference with vLLM
+- OpenAI-compatible API
+- 1B parameter model with 34k context length
+- Instruction-tuned for better responses
+- Optimized for GPU acceleration
+
+## Configuration
+- Port: 9000
+- GPU: Required (60GB+ VRAM)
+- Model: google/gemma-3-1b-it
+- Context Length: 128,000 tokens
+
+## Usage
+You can interact with the model using the OpenAI API format:
+```python
+import openai
+
+client = openai.Client(
+    base_url="http://localhost:9000/v1"
+)
+
+response = client.chat.completions.create(
+    model="Gemma-3-1b",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me about Gemma 3."}
+    ]
+)
+print(response.choices[0].message.content)
+``` 

--- a/templates/Gemma-3-1b /info.json
+++ b/templates/Gemma-3-1b /info.json
@@ -1,0 +1,7 @@
+{
+  "id": "gem1b",
+  "name": "Gemma 3 1B",
+  "description": "Google's Gemma 3 1B instruction-tuned model served via vLLM with OpenAI-compatible API",
+  "category": ["API", "LLM", "New"],
+  "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Google_%22G%22_logo.svg/768px-Google_%22G%22_logo.svg.png"
+} 

--- a/templates/Gemma-3-1b /job-definition.json
+++ b/templates/Gemma-3-1b /job-definition.json
@@ -1,0 +1,30 @@
+{
+  "ops": [
+    {
+      "id": "gem1b",
+      "args": {
+        "cmd": [
+          "/bin/sh",
+          "-c",
+          "python3 -m vllm.entrypoints.openai.api_server --model google/gemma-3-1b-it --served-model-name Gemma-3-1b --port 9000 --max-model-len 10000"
+        ],
+        "env": {
+          "HF_TOKEN": "fill_in_your_huggingface_token"
+        },
+        "gpu": true,
+        "image": "nosana/vllm:0.0.0",
+        "expose": 9000,
+        "entrypoint": []
+      },
+      "type": "container/run"
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "required_vram": 60
+    }
+  },
+  "type": "container",
+  "version": "0.1"
+}

--- a/templates/Gemma-3-4b /README.md
+++ b/templates/Gemma-3-4b /README.md
@@ -1,0 +1,35 @@
+# Gemma 3 4B
+
+Google's Gemma 3 4B instruction-tuned model served via vLLM with an OpenAI-compatible API endpoint.
+
+## Key Features
+- High-performance inference with vLLM
+- OpenAI-compatible API
+- 4B parameter model with 34k context length
+- Instruction-tuned for better responses
+- Optimized for GPU acceleration
+
+## Configuration
+- Port: 9000
+- GPU: Required (60GB+ VRAM)
+- Model: google/gemma-3-4b-it
+- Context Length: 428,000 tokens
+
+## Usage
+You can interact with the model using the OpenAI API format:
+```python
+import openai
+
+client = openai.Client(
+    base_url="http://localhost:9000/v1"
+)
+
+response = client.chat.completions.create(
+    model="Gemma-3-4b",
+    messages=[
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Tell me about Gemma 3."}
+    ]
+)
+print(response.choices[0].message.content)
+``` 

--- a/templates/Gemma-3-4b /info.json
+++ b/templates/Gemma-3-4b /info.json
@@ -1,0 +1,7 @@
+{
+  "id": "gem4b",
+  "name": "Gemma 3 4B",
+  "description": "Google's Gemma 3 4B instruction-tuned model served via vLLM with OpenAI-compatible API",
+  "category": ["API", "LLM", "New"],
+  "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/Google_%22G%22_logo.svg/768px-Google_%22G%22_logo.svg.png"
+} 

--- a/templates/Gemma-3-4b /job-definition.json
+++ b/templates/Gemma-3-4b /job-definition.json
@@ -1,0 +1,30 @@
+{
+  "ops": [
+    {
+      "id": "gem4b",
+      "args": {
+        "cmd": [
+          "/bin/sh",
+          "-c",
+          "python3 -m vllm.entrypoints.openai.api_server --model google/gemma-3-4b-it --served-model-name Gemma-3-4b --port 9000 --max-model-len 10000"
+        ],
+        "env": {
+          "HF_TOKEN": "fill_in_your_huggingface_token"
+        },
+        "gpu": true,
+        "image": "nosana/vllm:0.0.0",
+        "expose": 9000,
+        "entrypoint": []
+      },
+      "type": "container/run"
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "required_vram": 60
+    }
+  },
+  "type": "container",
+  "version": "0.1"
+}

--- a/templates/Mistral-7B-Instruct-v0.3/README.md
+++ b/templates/Mistral-7B-Instruct-v0.3/README.md
@@ -1,0 +1,45 @@
+**A high-throughput and memory-efficient inference engine for running Mistral-7B-v3 using vLLM.**
+
+## Description
+
+This template provides an OpenAI-compatible API server for the **Mistral-7B-v3** model, optimized for performance using **vLLM**. This version leverages the strengths of Mistral's dense transformer architecture, providing efficient and high-quality responses for various general-purpose language tasks.
+
+## Usage Recommendations
+
+To get optimal performance and reliability from **Mistral-7B-v3**, we suggest the following guidelines:
+
+- Use a temperature between **0.5 and 0.7** (default: **0.6**) to balance creativity and coherence.
+- While Mistral does not require specific prompting formats, using **clear and concise** instructions yields better results.
+- For structured outputs (e.g., code or math), consider specifying formatting expectations in the prompt.
+- Perform multiple runs and average outputs when benchmarking or evaluating consistency.
+
+## Model Details
+
+- **Name**: Mistral-7B-v3
+- **Base Model**: Mistral (Dense Transformer)
+- **Size**: 7 billion parameters
+- **Architecture**: Decoder-only, optimized for performance and scalability
+
+## Usage
+
+The API follows the **OpenAI API format** and can be accessed via HTTP requests to **port 9000**. The model is served under the name `"Mistral-7B-v3"`.
+
+Example OpenAI-style request:
+
+```json
+{
+  "model": "Mistral-7B-v3",
+  "messages": [{"role": "user", "content": "Explain quantum entanglement in simple terms."}],
+  "temperature": 0.6
+}
+```
+
+## License
+
+The **Mistral-7B-v3** model is open-weight and licensed under the **Apache 2.0 License**, allowing for commercial use. Refer to the official Mistral documentation for further usage details and licensing terms.
+
+## Links
+
+- [Mistral AI GitHub Repository](https://github.com/mistralai)
+- [vLLM Documentation](https://github.com/vllm-project/vllm)
+

--- a/templates/Mistral-7B-Instruct-v0.3/info.json
+++ b/templates/Mistral-7B-Instruct-v0.3/info.json
@@ -1,0 +1,8 @@
+{
+  "id": "mistral7b",
+  "name": "Mistral-7B Instruct v0.3",
+  "description": "High-performance inference API for the Mistral-7B Instruct language model using vLLM and OpenAI-compatible endpoints.",
+  "category": ["API", "LLM"],
+  "icon": "https://avatars.githubusercontent.com/u/132372032?s=200&v=4",
+  "github_url": "https://github.com/mistralai"
+}

--- a/templates/Mistral-7B-Instruct-v0.3/job-definition.json
+++ b/templates/Mistral-7B-Instruct-v0.3/job-definition.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "required_vram": 16
+    }
+  },
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "mistral7b",
+      "args": {
+        "entrypoint": [],
+        "cmd": [
+          "/bin/sh",
+          "-c",
+          "python3 -m vllm.entrypoints.openai.api_server --model mistralai/Mistral-7B-Instruct-v0.3 --served-model-name Mistral-7B-v3 --port 9000 --max-model-len 32768"
+        ],
+        "image": "docker.io/vllm/vllm-openai:v0.7.2",
+        "gpu": true,
+        "expose": 9000
+      }
+    }
+  ]
+}


### PR DESCRIPTION
###  Add Templates for Gemma and Mistral

####  What's Added:
- **Gemma Templates**:
  - `gemma-3-1b`
  - `gemma-3-4b`
  - `gemma-3-12b`
- **Mistral Template**:
  - `mistral-7b-instruct-v0.3` (via `vLLM`, OpenAI-compatible API)

#### Includes:
- Container job definitions for each model using `vLLM` or `TGI` inference
- Metadata definitions (`id`, `name`, `description`, `category`, `icon`, `github_url`)
- Exposed ports, GPU requirements, and sensible context lengths

#### Notes:
- All templates are designed for plug-and-play use with dashboard-triggered execution
- Mistral uses the official `mistralai/Mistral-7B-Instruct-v0.3` via `vllm-openai:v0.7.2`
