### PR TITLE
Add BigScience BLOOM and Microsoft Phi4

### DIFF
--- a/templates/Bloom/README.md
+++ b/templates/Bloom/README.md
@@ -1,0 +1,81 @@
+# BLOOM
+
+A powerful multilingual language model with 176 billion parameters supporting 46 languages and 13 programming languages, packaged as a containerized service for deployment on the Nosana decentralized compute network.
+
+## Description
+
+BLOOM (BigScience Large Open-science Open-access Multilingual Language Model) is a decoder-only transformer language model developed by the BigScience workshop, featuring exceptional multilingual capabilities. This integration packages BLOOM as a deployable job on Nosana's decentralized compute infrastructure, providing efficient access to this state-of-the-art language model.
+
+## Features
+
+- Support for 46 natural languages and 13 programming languages
+- Available in multiple sizes (176B, 7.1B, 3B, 1.7B, 560M parameters)
+- Optimized for distributed inferencing across Nosana nodes
+- RESTful API for text generation and embeddings
+- Containerized deployment with horizontal scaling
+
+## Usage
+
+The model is served through a RESTful API with endpoints for text generation and embeddings. Configuration settings allow for parameter adjustment and resource allocation based on deployment needs.
+
+## Model Details
+
+- **Name**: BLOOM
+- **Architecture**: 
+  - Autoregressive decoder-only transformer (GPT-like)
+  - 70 layers
+  - 112 attention heads per layer
+  - Hidden dimensionality of 14336
+  - 2048 tokens sequence length
+  - ALiBi positional embeddings
+  - GeLU activation function
+- **Size**: 
+  - 176B parameters (full model)
+  - Smaller variants available (7.1B, 3B, 1.7B, 560M)
+  - Full checkpoint size: 329GB (bf16 weights only), 2.3TB with optimizer states
+- **Training Data**:
+  - 341.6 billion tokens (1.5 TB of text data)
+  - Tokenizer vocabulary: 250,680 tokens
+  - Trained on text from 46 natural languages
+  - Includes 13 programming languages
+- **Training Infrastructure**:
+  - Trained on 384 A100 GPUs (80GB memory each)
+  - One copy of the model required 48 GPUs (using 60GB memory per GPU)
+  - Training throughput: ~150 TFLOPs
+  - Training duration: 3-4 months (started March 11, 2022)
+  - Trained on the Jean Zay public supercomputer
+- **Capabilities**: 
+  - Text generation
+  - Multilingual processing
+  - Code generation
+  - Vector embeddings
+  - Zero-shot task performance
+
+## Environmental Considerations
+
+- Jean Zay supercomputer is primarily powered by nuclear energy, a low carbon energy source
+- Computing infrastructure designed for high efficiency, with waste heat repurposed for heating buildings on campus
+- Detailed carbon emissions estimates for training and inference are being developed
+
+## License
+
+This model is released under the RAIL (Responsible AI License), an open license allowing commercial use with ethical restrictions.
+
+## Resources
+
+### Official Resources
+- [BLOOM GitHub Repository](https://github.com/bigscience-workshop/bloom)
+- [BLOOM on HuggingFace](https://huggingface.co/bigscience/bloom)
+- [BLOOM Research Paper](https://arxiv.org/abs/2211.05100)
+- [BigScience Main Website](https://bigscience.huggingface.co/)
+- [BigScience on X](https://x.com/BigscienceW)
+
+### Technical Documentation
+- [Model Architecture Details](https://github.com/bigscience-workshop/bigscience/tree/master/train/tr11-176B-ml)
+- [Training Logs & Tensorboard](https://huggingface.co/bigscience/tr11-176B-ml-logs/tensorboard)
+- [Technical Engineering Chronicles](https://github.com/bigscience-workshop/bigscience/blob/master/train/tr11-176B-ml/chronicles.md)
+
+### Blog Posts
+- [Architecture & Training Decisions](https://bigscience.huggingface.co/blog/what-language-model-to-train-if-you-have-two-million-gpu-hours)
+- [Dataset Creation Process](https://bigscience.huggingface.co/blog/building-a-tb-scale-multilingual-dataset-for-language-modeling)
+- [Hardware Engineering Insights](https://bigscience.huggingface.co/blog/which-hardware-to-train-a-176b-parameters-model)

--- a/templates/Bloom/README.md
+++ b/templates/Bloom/README.md
@@ -1,10 +1,10 @@
 # BLOOM
 
-A powerful multilingual language model with 176 billion parameters supporting 46 languages and 13 programming languages, packaged as a containerized service for deployment on the Nosana decentralized compute network.
+A powerful open-source multilingual language model with 176 billion parameters supporting 46 languages and 13 programming languages, developed specifically for academic institutions, nonprofit organizations, and smaller research labs.
 
 ## Description
 
-BLOOM (BigScience Large Open-science Open-access Multilingual Language Model) is a decoder-only transformer language model developed by the BigScience workshop, featuring exceptional multilingual capabilities. This integration packages BLOOM as a deployable job on Nosana's decentralized compute infrastructure, providing efficient access to this state-of-the-art language model.
+BLOOM (BigScience Large Open-science Open-access Multilingual Language Model) is a decoder-only transformer language model developed by the BigScience workshop, a collaborative effort dedicated to democratizing access to large language model research. As a fully open-source alternative to proprietary commercial models, BLOOM is specifically designed to serve the needs of academia, nonprofits, and smaller research labs.
 
 ## Features
 

--- a/templates/Bloom/info.json
+++ b/templates/Bloom/info.json
@@ -1,0 +1,8 @@
+{
+    "id": "bloom",
+    "name": "Bloom",
+    "description": "An open-source LLM by BigScience developed for academia, nonprofits, and smaller research labs with support for over 46 languages including Spanish, French, and Arabic.",
+    "category": ["LLM", "API"],
+    "icon": "https://pbs.twimg.com/profile_images/1450720169576312832/LcT4cxXq_400x400.jpg",
+    "github_url": "https://github.com/huggingface/transformers"
+  } 

--- a/templates/Bloom/job-definition.json
+++ b/templates/Bloom/job-definition.json
@@ -1,0 +1,24 @@
+{
+    "ops": [
+      {
+        "id": "bloom",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model bigscience/bloom --host 0.0.0.0 --port 8000"
+          ],
+          "env": {
+            "HF_TOKEN": "fill_in_your_huggingface_token"
+          },
+          "gpu": true,
+          "image": "huggingface/transformers-pytorch-gpu:latest",
+          "expose": 9000,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "type": "container",
+    "version": "0.1"
+  }

--- a/templates/Microsoft-Phi/README.md
+++ b/templates/Microsoft-Phi/README.md
@@ -1,0 +1,58 @@
+# Microsoft Phi-4
+
+A 14-billion parameter language model developed by Microsoft Research. It is part of the Phi model family, emphasizing data quality and reasoning capabilities over pure scale.
+
+## Description
+
+Microsoft Phi-4 represents a significant advancement in language model technology, featuring 14 billion parameters and demonstrating that exceptional reasoning and cognitive capabilities can be achieved through prioritizing data quality over sheer model size. As part of the Phi model family, Phi-4 is designed to be highly efficient while maintaining strong performance across reasoning tasks, coding challenges, and general intelligence benchmarks, making it more accessible for deployment compared to much larger models while still delivering competitive results.
+
+## Features
+
+Phi-4 is specifically designed for:
+
+- STEM reasoning & problem-solving (math, physics, coding, logic)
+- Memory and compute-efficient applications
+- Educational and research applications
+- Conversational AI and chatbot experiences
+
+## Usage
+
+The model is served through a RESTful API with endpoints for both chat completions and standard completions. Various parameters can be adjusted to control generation behavior, including temperature, top-p, and max tokens.
+
+## Model Details
+
+- **Name**: Phi-4
+- **Architecture**: 
+  - Decoder-only transformer architecture
+  - Advanced context handling capabilities
+  - Optimized attention mechanisms
+  - Improved tokenization strategy
+- **Size**: 
+  - 14B parameters (standard model)
+  - Relatively compact size enables more efficient deployment compared to larger models
+- **Training Data**:
+  - Trained on a diverse, carefully curated dataset
+  - Focus on reasoning, problem-solving, and coding examples
+  - Strong emphasis on mathematical reasoning capabilities
+  - Includes diverse programming language examples
+- **Training Infrastructure**:
+  - Developed by Microsoft Research using optimized training techniques
+- **Capabilities**: 
+  - Text generation
+  - Multi-turn conversations
+  - Code generation and completion
+  - Mathematical reasoning
+  - Problem-solving across diverse domains
+
+## License
+
+This model is available for commercial and research use under Microsoft's licensing terms, which support both commercial applications and academic research.
+
+## Resources
+
+### Official Resources
+- [Microsoft Phi-4 GitHub Repository](https://github.com/microsoft/PhiCookBook)
+- [Phi-4 on HuggingFace](https://huggingface.co/microsoft/phi-4)
+- [Microsoft Blog post on Phi-4](https://techcommunity.microsoft.com/blog/aiplatformblog/introducing-phi-4-microsoft%E2%80%99s-newest-small-language-model-specializing-in-comple/4357090)
+- [Microsoft AI on X](https://twitter.com/MSFTResearch)
+- [Microsoft AI on Discord](https://discord.com/invite/ByRwuEEgH4?WT.mc_id=aiml-137032-kinfeylo)

--- a/templates/Microsoft-Phi/info.json
+++ b/templates/Microsoft-Phi/info.json
@@ -1,0 +1,8 @@
+{
+    "id": "phi-4",
+    "name": "Microsoft Phi-4",
+    "description": "A 14-billion parameter language model developed by Microsoft Research. It is part of the Phi model family, emphasizing data quality and reasoning capabilities over pure scale.",
+    "category": ["LLM", "API"],
+    "icon": "https://mailmeteor.com/logos/assets/PNG/Microsoft_Logo_512px.png",
+    "github_url": "https://github.com/microsoft/PhiCookBook"
+  }

--- a/templates/Microsoft-Phi/job-definition.json
+++ b/templates/Microsoft-Phi/job-definition.json
@@ -1,0 +1,24 @@
+{
+    "ops": [
+      {
+        "id": "phi4",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model microsoft/phi-4 --host 0.0.0.0 --port 8000"
+          ],
+          "env": {
+            "HF_TOKEN": "fill_in_your_huggingface_token"
+          },
+          "gpu": true,
+          "image": "huggingface/transformers-pytorch-gpu:latest",
+          "expose": 9000,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "type": "container",
+    "version": "0.1"
+  }


### PR DESCRIPTION
Add BigScience BLOOM and Microsoft Phi-4 Templates

This PR adds support for running BigScience BLOOM and Microsoft Phi-4 models as Nosana templates.

Changes:
- Add configuration for BLOOM model (176B parameters)
- Add configuration for Phi-4 model (14B variant)