### PR TITLE
10 new LLM Templates

### DIFF
--- a/templates/Deepseek-R1-distill-Llama/README.md
+++ b/templates/Deepseek-R1-distill-Llama/README.md
@@ -1,2 +1,4 @@
+# DeepSeek R1 Distill LLaMA
+
 ## Description
 This template runs DeepSeek's distilled LLaMA, which is fast and optimized for real-world tasks. Requires a GPU with at least 32GB of VRAM.

--- a/templates/Deepseek-R1-distill-Llama/README.md
+++ b/templates/Deepseek-R1-distill-Llama/README.md
@@ -1,0 +1,2 @@
+## Description
+This template runs DeepSeek's distilled LLaMA, which is fast and optimized for real-world tasks. Requires a GPU with at least 32GB of VRAM.

--- a/templates/Deepseek-R1-distill-Llama/info.json
+++ b/templates/Deepseek-R1-distill-Llama/info.json
@@ -1,5 +1,5 @@
 {
-    "id": "deepseek-r1-distill-llama",
+    "id": "dist-llama",
     "name": "DeepSeek R1 Distill LLaMA",
     "description": "Runs DeepSeek's distilled LLaMA, optimized for real-world tasks.",
     "category": ["API", "LLM"],

--- a/templates/Deepseek-R1-distill-Llama/info.json
+++ b/templates/Deepseek-R1-distill-Llama/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "deepseek-r1-distill-llama",
+    "name": "DeepSeek R1 Distill LLaMA",
+    "description": "Runs DeepSeek's distilled LLaMA, optimized for real-world tasks.",
+    "category": ["API", "LLM"],
+    "icon": "https://avatars.githubusercontent.com/u/148330874?s=48&v=4"
+  }

--- a/templates/Deepseek-R1-distill-Llama/job-definition.json
+++ b/templates/Deepseek-R1-distill-Llama/job-definition.json
@@ -1,0 +1,27 @@
+{
+    "ops": [
+      {
+        "id": "deepseek-r1-distill-llama",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/deepseek-r1-distill-llama --served-model-name deepseek-r1-distill-llama --port 9000 --max-model-len 8192"
+          ],
+          "gpu": true,
+          "image": "docker.io/vllm/vllm-openai:v0.7.2",
+          "expose": 9000,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "meta": {
+      "trigger": "dashboard",
+      "system_requirements": {
+        "required_vram": 32
+      }
+    },
+    "type": "container",
+    "version": "0.1"
+  }

--- a/templates/Llama3.2/README.md
+++ b/templates/Llama3.2/README.md
@@ -1,0 +1,2 @@
+## Description
+This template runs LLaMA 3.2, which is reliable for coding, chat, and Q&A tasks. Requires a GPU with at least 28GB of VRAM.

--- a/templates/Llama3.2/README.md
+++ b/templates/Llama3.2/README.md
@@ -1,2 +1,5 @@
+# LLaMA 3.2 LLM
+
 ## Description
 This template runs LLaMA 3.2, which is reliable for coding, chat, and Q&A tasks. Requires a GPU with at least 28GB of VRAM.
+

--- a/templates/Llama3.2/info.json
+++ b/templates/Llama3.2/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "llama3.2",
+    "name": "LLaMA 3.2 LLM",
+    "description": "Runs LLaMA 3.2, reliable for coding, chat, and Q&A.",
+    "category": ["API", "LLM"],
+    "icon": "https://custom.typingmind.com/assets/models/llama.png"
+  }

--- a/templates/Llama3.2/job-definition.json
+++ b/templates/Llama3.2/job-definition.json
@@ -1,0 +1,28 @@
+{
+    "ops": [
+      {
+        "id": "llama3.2",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/llama3.2 --served-model-name llama3.2 --port 9000 --max-model-len 8192"
+          ],
+          "gpu": true,
+          "image": "docker.io/vllm/vllm-openai:v0.7.2",
+          "expose": 9000,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "meta": {
+      "trigger": "dashboard",
+      "system_requirements": {
+        "required_vram": 28
+      }
+    },
+    "type": "container",
+    "version": "0.1"
+  }
+  

--- a/templates/Llama3.3/README.md
+++ b/templates/Llama3.3/README.md
@@ -1,0 +1,4 @@
+# LLaMA 3.3 LLM
+
+## Description
+This template runs the latest LLaMA 3.3 model, featuring improved reasoning and generation capabilities. Requires a GPU with at least 30GB of VRAM.

--- a/templates/Llama3.3/info.json
+++ b/templates/Llama3.3/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "llama3.3",
+    "name": "LLaMA 3.3 LLM",
+    "description": "Runs the latest LLaMA 3.3 model with improved reasoning and generation.",
+    "category": ["API", "LLM"],
+    "icon": "https://custom.typingmind.com/assets/models/llama.png"
+  }

--- a/templates/Llama3.3/job-definition.json
+++ b/templates/Llama3.3/job-definition.json
@@ -1,0 +1,27 @@
+{
+    "ops": [
+      {
+        "id": "llama3.3",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/llama3.3 --served-model-name llama3.3 --port 9004 --max-model-len 8192"
+          ],
+          "gpu": true,
+          "image": "docker.io/vllm/vllm-openai:v0.7.2",
+          "expose": 9004,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "meta": {
+      "trigger": "dashboard",
+      "system_requirements": {
+        "required_vram": 30
+      }
+    },
+    "type": "container",
+    "version": "0.1"
+  }

--- a/templates/Mistral/README.md
+++ b/templates/Mistral/README.md
@@ -1,0 +1,2 @@
+## Description
+This template runs the Mistral model, known for its efficiency and top-tier performance. Requires a GPU with at least 28GB of VRAM.

--- a/templates/Mistral/README.md
+++ b/templates/Mistral/README.md
@@ -1,2 +1,5 @@
+# Mistral LLM
+
 ## Description
 This template runs the Mistral model, known for its efficiency and top-tier performance. Requires a GPU with at least 28GB of VRAM.
+

--- a/templates/Mistral/info.json
+++ b/templates/Mistral/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "mistral",
+    "name": "Mistral LLM",
+    "description": "Runs the efficient Mistral model with top-tier performance.",
+    "category": ["API", "LLM", "Efficiency"],
+    "icon": "https://mistral.ai/_next/image?url=%2Fimg%2FM-beige.svg&w=1920&q=75"
+  }

--- a/templates/Mistral/info.json
+++ b/templates/Mistral/info.json
@@ -2,6 +2,6 @@
     "id": "mistral",
     "name": "Mistral LLM",
     "description": "Runs the efficient Mistral model with top-tier performance.",
-    "category": ["API", "LLM", "Efficiency"],
+    "category": ["API", "LLM"],
     "icon": "https://mistral.ai/_next/image?url=%2Fimg%2FM-beige.svg&w=1920&q=75"
   }

--- a/templates/Mistral/job-definition.json
+++ b/templates/Mistral/job-definition.json
@@ -1,12 +1,12 @@
 {
     "ops": [
       {
-        "id": "dist-llama",
+        "id": "mistral",
         "args": {
           "cmd": [
             "/bin/sh",
             "-c",
-            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/deepseek-r1-distill-llama --served-model-name deepseek-r1-distill-llama --port 9000 --max-model-len 8192"
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/mistral --served-model-name mistral --port 9000 --max-model-len 8192"
           ],
           "gpu": true,
           "image": "docker.io/vllm/vllm-openai:v0.7.2",
@@ -19,7 +19,7 @@
     "meta": {
       "trigger": "dashboard",
       "system_requirements": {
-        "required_vram": 32
+        "required_vram": 28
       }
     },
     "type": "container",

--- a/templates/Mxbai-Embed-Large/README.md
+++ b/templates/Mxbai-Embed-Large/README.md
@@ -1,0 +1,5 @@
+# mxbai-embed-large Embeddings
+
+## Description
+This template runs the mxbai-embed-large model, designed for generating large embeddings. Requires a GPU with at least 12GB of VRAM.
+

--- a/templates/Mxbai-Embed-Large/info.json
+++ b/templates/Mxbai-Embed-Large/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "mxbai-lar",
+    "name": "mxbai-embed-large Embeddings",
+    "description": "Runs the mxbai-embed-large model for generating large embeddings.",
+    "category": ["API"],
+    "icon": "https://djeqr6to3dedg.cloudfront.net/repo-logos/ai/mxbai-embed-large/live/logo-1743008530490.png"
+  }

--- a/templates/Mxbai-Embed-Large/job-definition.json
+++ b/templates/Mxbai-Embed-Large/job-definition.json
@@ -1,0 +1,28 @@
+{
+    "ops": [
+      {
+        "id": "mxbai-lar",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/mxbai-embed-large --served-model-name mxbai-embed-large --port 9000 --max-model-len 2048"
+          ],
+          "gpu": true,
+          "image": "docker.io/vllm/vllm-openai:v0.7.2",
+          "expose": 9000,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "meta": {
+      "trigger": "dashboard",
+      "system_requirements": {
+        "required_vram": 12
+      }
+    },
+    "type": "container",
+    "version": "0.1"
+  }
+  

--- a/templates/Phi4/README.md
+++ b/templates/Phi4/README.md
@@ -1,0 +1,5 @@
+# Phi-4 LLM
+
+## Description
+This template runs Microsoft's Phi-4 model, which is surprisingly capable at reasoning and code generation. Requires a GPU with at least 20GB of VRAM.
+

--- a/templates/Phi4/info.json
+++ b/templates/Phi4/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "phi4",
+    "name": "Phi-4 LLM",
+    "description": "Runs Microsoft's Phi-4 model, known for reasoning and code capabilities.",
+    "category": ["API", "LLM"],
+    "icon": "https://hub.continue.dev/sparkles/sparkle4.jpg"
+  }

--- a/templates/Phi4/job-definition.json
+++ b/templates/Phi4/job-definition.json
@@ -1,12 +1,12 @@
 {
     "ops": [
       {
-        "id": "dist-llama",
+        "id": "phi4",
         "args": {
           "cmd": [
             "/bin/sh",
             "-c",
-            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/deepseek-r1-distill-llama --served-model-name deepseek-r1-distill-llama --port 9000 --max-model-len 8192"
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/phi4 --served-model-name phi4 --port 9000 --max-model-len 8192"
           ],
           "gpu": true,
           "image": "docker.io/vllm/vllm-openai:v0.7.2",
@@ -19,7 +19,7 @@
     "meta": {
       "trigger": "dashboard",
       "system_requirements": {
-        "required_vram": 32
+        "required_vram": 20
       }
     },
     "type": "container",

--- a/templates/QwQ/README.md
+++ b/templates/QwQ/README.md
@@ -1,2 +1,4 @@
+# QWQ Experimental LLM
+
 ## Description
 This template runs an experimental Qwen variant, which is lean, fast, and a bit mysterious. Requires a GPU with at least 20GB of VRAM.

--- a/templates/QwQ/README.md
+++ b/templates/QwQ/README.md
@@ -1,0 +1,2 @@
+## Description
+This template runs an experimental Qwen variant, which is lean, fast, and a bit mysterious. Requires a GPU with at least 20GB of VRAM.

--- a/templates/QwQ/info.json
+++ b/templates/QwQ/info.json
@@ -2,6 +2,6 @@
     "id": "qwq",
     "name": "QWQ Experimental LLM",
     "description": "Runs an experimental Qwen variant, lean and fast.",
-    "category": ["AI", "LLM", "Experimental"],
+    "category": ["API", "LLM"],
     "icon": "https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png"
   }

--- a/templates/QwQ/info.json
+++ b/templates/QwQ/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "qwq",
+    "name": "QWQ Experimental LLM",
+    "description": "Runs an experimental Qwen variant, lean and fast.",
+    "category": ["AI", "LLM", "Experimental"],
+    "icon": "https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png"
+  }

--- a/templates/QwQ/job-definition.json
+++ b/templates/QwQ/job-definition.json
@@ -1,12 +1,12 @@
 {
     "ops": [
       {
-        "id": "dist-llama",
+        "id": "qwq",
         "args": {
           "cmd": [
             "/bin/sh",
             "-c",
-            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/deepseek-r1-distill-llama --served-model-name deepseek-r1-distill-llama --port 9000 --max-model-len 8192"
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/qwq --served-model-name qwq --port 9000 --max-model-len 8192"
           ],
           "gpu": true,
           "image": "docker.io/vllm/vllm-openai:v0.7.2",
@@ -19,7 +19,7 @@
     "meta": {
       "trigger": "dashboard",
       "system_requirements": {
-        "required_vram": 32
+        "required_vram": 20
       }
     },
     "type": "container",

--- a/templates/Smollm2/README.md
+++ b/templates/Smollm2/README.md
@@ -1,2 +1,4 @@
+# SmolLLM 2 LLM
+
 ## Description
 This template runs SmolLLM 2, a tiny LLM designed for speed and edge devices. Requires a GPU with at least 8GB of VRAM.

--- a/templates/Smollm2/README.md
+++ b/templates/Smollm2/README.md
@@ -1,0 +1,2 @@
+## Description
+This template runs SmolLLM 2, a tiny LLM designed for speed and edge devices. Requires a GPU with at least 8GB of VRAM.

--- a/templates/Smollm2/info.json
+++ b/templates/Smollm2/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "smollm2",
+    "name": "SmolLLM 2 LLM",
+    "description": "Runs the SmolLLM 2 model, optimized for speed and edge devices.",
+    "category": ["AI", "LLM", "Edge", "Speed"],
+    "icon": "https://huggingfacetb-smollm2-1-7b-instruct-webgpu.static.hf.space/logo.png"
+  }

--- a/templates/Smollm2/info.json
+++ b/templates/Smollm2/info.json
@@ -2,6 +2,6 @@
     "id": "smollm2",
     "name": "SmolLLM 2 LLM",
     "description": "Runs the SmolLLM 2 model, optimized for speed and edge devices.",
-    "category": ["AI", "LLM", "Edge", "Speed"],
+    "category": ["API", "LLM"],
     "icon": "https://huggingfacetb-smollm2-1-7b-instruct-webgpu.static.hf.space/logo.png"
   }

--- a/templates/Smollm2/job-definition.json
+++ b/templates/Smollm2/job-definition.json
@@ -1,12 +1,12 @@
 {
     "ops": [
       {
-        "id": "dist-llama",
+        "id": "smollm2",
         "args": {
           "cmd": [
             "/bin/sh",
             "-c",
-            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/deepseek-r1-distill-llama --served-model-name deepseek-r1-distill-llama --port 9000 --max-model-len 8192"
+            "python3 -m vllm.entrypoints.openai.api_server --model docker/ai/smollm2 --served-model-name smollm2 --port 9000 --max-model-len 4096"
           ],
           "gpu": true,
           "image": "docker.io/vllm/vllm-openai:v0.7.2",
@@ -19,7 +19,7 @@
     "meta": {
       "trigger": "dashboard",
       "system_requirements": {
-        "required_vram": 32
+        "required_vram": 8
       }
     },
     "type": "container",

--- a/templates/gemma3/README.md
+++ b/templates/gemma3/README.md
@@ -1,21 +1,4 @@
-# Gemma 3 API Server
+# Gemma 3 LLM
 
-This template runs the Gemma 3 model using `vllm.entrypoints.openai.api_server` with OpenAI-compatible API endpoints.
-
-## What it does
-
-- Loads the Gemma 3 model from a Docker image.
-- Serves the model via HTTP on port `9000`.
-- Uses GPU acceleration.
-
-## Parameters
-
-- **Model**: `docker.io/docker/gemma3`
-- **Served Name**: `Gemma-3`
-- **Port**: `9000`
-- **Max Tokens**: `34000`
-
-## Requirements
-
-- GPU with at least 60GB VRAM (e.g., A100 80GB or higher)
-- Docker runtime
+## Description
+This template runs Google's Gemma 3 LLM, providing a powerful chat and generation model through a Docker container using vLLM's OpenAI API server. It requires a GPU with at least 24GB of VRAM.

--- a/templates/gemma3/README.md
+++ b/templates/gemma3/README.md
@@ -1,0 +1,21 @@
+# Gemma 3 API Server
+
+This template runs the Gemma 3 model using `vllm.entrypoints.openai.api_server` with OpenAI-compatible API endpoints.
+
+## What it does
+
+- Loads the Gemma 3 model from a Docker image.
+- Serves the model via HTTP on port `9000`.
+- Uses GPU acceleration.
+
+## Parameters
+
+- **Model**: `docker.io/docker/gemma3`
+- **Served Name**: `Gemma-3`
+- **Port**: `9000`
+- **Max Tokens**: `34000`
+
+## Requirements
+
+- GPU with at least 60GB VRAM (e.g., A100 80GB or higher)
+- Docker runtime

--- a/templates/gemma3/info.json
+++ b/templates/gemma3/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "gem3",
+    "name": "Gemma 3",
+    "description": "Google's Gemma 3 instruction-tuned model served via vLLM with OpenAI-compatible API",
+    "category": ["API", "LLM", "New"],
+    "icon": "https://custom.typingmind.com/assets/models/gemma.jpg"
+  } 

--- a/templates/gemma3/job-definition.json
+++ b/templates/gemma3/job-definition.json
@@ -1,0 +1,27 @@
+{
+    "ops": [
+      {
+        "id": "gemma3",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model docker.io/docker/gemma3 --served-model-name Gemma-3 --port 9000 --max-model-len 34000"
+          ],
+          "gpu": true,
+          "image": "docker.io/docker/gemma3",
+          "expose": 9000,
+          "entrypoint": []
+        },
+        "type": "container/run"
+      }
+    ],
+    "meta": {
+      "trigger": "dashboard",
+      "system_requirements": {
+        "required_vram": 60
+      }
+    },
+    "type": "container",
+    "version": "0.1"
+  }

--- a/templates/qwen2.5/README.md
+++ b/templates/qwen2.5/README.md
@@ -1,0 +1,6 @@
+# Qwen 2.5 Inference API
+
+## Description
+This template runs Qwen 2.5 (a powerful large language model) using vLLM and exposes it as an OpenAI-compatible API server on port 9000. It utilizes GPU resources for inference and supports up to 34,000 tokens in context.
+
+Useful if you want to test or deploy Qwen 2.5 using OpenAI tools or clients.

--- a/templates/qwen2.5/info.json
+++ b/templates/qwen2.5/info.json
@@ -1,0 +1,7 @@
+{
+    "id": "qwen2.5",
+    "name": "Qwen 2.5 Inference API",
+    "description": "Runs Qwen 2.5 as an OpenAI-compatible inference server on port 9001.",
+    "category": ["API", "LLM"],
+    "icon": "https://cdn-avatars.huggingface.co/v1/production/uploads/620760a26e3b7210c2ff1943/-s1gyJfvbE1RgO5iBeNOi.png"
+  }

--- a/templates/qwen2.5/job-definition.json
+++ b/templates/qwen2.5/job-definition.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.1",
+    "type": "container",
+    "meta": {
+      "trigger": "dashboard",
+      "system_requirements": {
+        "required_vram": 60
+      }
+    },
+    "ops": [
+      {
+        "id": "qwen2.5",
+        "type": "container/run",
+        "args": {
+          "cmd": [
+            "/bin/sh",
+            "-c",
+            "python3 -m vllm.entrypoints.openai.api_server --model docker.io/docker/qwen2.5 --served-model-name Qwen-2.5 --port 9000 --max-model-len 34000"
+          ],
+          "gpu": true,
+          "image": "docker.io/docker/qwen2.5",
+          "expose": 9000,
+          "entrypoint": []
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
This pull request introduces ten new job-definition templates for various LLMs through the vLLM OpenAI API server. Each template is configured for optimal performance and resource utilization.

* **`dist-llama` (DeepSeek R1 Distill Llama):**
    * Model: DeepSeek R1 Distill Llama
    * `max_model_len`: 8192 (supports extended context)
    * `required_vram`: 32GB
    * Image: `vllm/vllm-openai:v0.7.2`
* **`gemma3` (Google Gemma 3):**
    * Model: Google Gemma 3
    * `max_model_len`: 34000 (supports very long contexts)
    * `required_vram`: 60GB
    * Image: `docker.io/docker/gemma3`
* **`llama3.2` and `llama3.3` (Llama 3 Variants):**
    * Model: Llama 3 variants
    * `max_model_len`: 8192
    * `llama3.2` `required_vram`: 28GB
    * `llama3.3` `required_vram`: 30GB
    * Image: `vllm/vllm-openai:v0.7.2`
* **`mistral` (Mistral):**
    * Model: Mistral
    * `max_model_len`: 8192
    * `required_vram`: 28GB
    * Image: `vllm/vllm-openai:v0.7.2`
* **`mxbai-lar` (MXBai Embed Large):**
    * Model: MXBai Embed Large (embedding model)
    * `max_model_len`: 2048
    * `required_vram`: 12GB
    * Image: `vllm/vllm-openai:v0.7.2`
* **`phi4` (Phi 4):**
    * Model: Phi 4
    * `max_model_len`: 8192
    * `required_vram`: 20GB
    * Image: `vllm/vllm-openai:v0.7.2`
* **`qwen2.5` (Qwen 2.5):**
    * Model: Qwen 2.5
    * `max_model_len`: 34000 (supports very long contexts)
    * `required_vram`: 60GB
    * Image: `docker.io/docker/qwen2.5`
* **`qwq` (Qwq):**
    * Model: Qwq
    * `max_model_len`: 8192
    * `required_vram`: 20GB
    * Image: `vllm/vllm-openai:v0.7.2`
* **`smollm2` (Smollm2):**
    * Model: Smollm2
    * `max_model_len`: 4096
    * `required_vram`: 8GB
    * Image: `vllm/vllm-openai:v0.7.2`
