### PR TITLE
feat: drive benchmark operation timeout from benchmarks.json

### DIFF
--- a/templates/GLM-47-flash/benchmarks.json
+++ b/templates/GLM-47-flash/benchmarks.json
@@ -4,6 +4,7 @@
       "glm-47-flash-q4",
       "glm-47-flash-bf16"
     ],
+    "timeoutSeconds": 1200,
     "metrics": [
       {
         "key": "tokens_per_second",

--- a/templates/Gemma4/benchmarks.json
+++ b/templates/Gemma4/benchmarks.json
@@ -6,6 +6,7 @@
       "26b",
       "31b"
     ],
+    "timeoutSeconds": 1200,
     "metrics": [
       {
         "key": "tokens_per_second",

--- a/validation/schema.validation.js
+++ b/validation/schema.validation.js
@@ -45,6 +45,9 @@ const OpsOverrides = z
 const BenchmarkGroup = z
   .object({
     variants: z.array(z.string().min(1)).min(1),
+    // Max run time (seconds) for the benchmark ops; the node kills the op past
+    // this. Optional — the host manager falls back to its default when omitted.
+    timeoutSeconds: z.number().int().positive().optional(),
     metrics: z.array(Metric).min(1),
     // Op structure is validated by the kit's validateOps; here we only require objects.
     support_ops: z.array(z.object({}).passthrough()).min(1),


### PR DESCRIPTION
## What
Add an optional `timeoutSeconds` to each benchmark group in `benchmarks.json` and set **Gemma4** and **GLM-47-flash** to **1200s**.

## Why
The host manager stamps each benchmark op's `execution.timeout` from the operation's `timeoutSeconds`, which the node enforces (clock starts when the container is running — after image pull). Until now that value was only the hardcoded **300s** default, which cut long benchmarks short (e.g. Pro 6000 timing out mid-run while a large model was still loading + warming up). 1200s gives headroom for model load into VRAM + `WARMUP_REQUEST_TIMEOUT` (300s) + the `DURATION` (100s) run.

## Changes
- `templates/Gemma4/benchmarks.json`, `templates/GLM-47-flash/benchmarks.json`: `"timeoutSeconds": 1200` on the group.
- `validation/schema.validation.js`: accept optional `timeoutSeconds` (positive int) on the benchmark group.

## Companion
Requires host-manager MR to read/persist the field: nosana-ci/apps/platform/host-manager!140

## Notes
- Optional field — omitting it falls back to the host manager's default (300s).
- On the next template refresh, existing benchmark operations converge to the new timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)