### PR TITLE
feat: drive benchmark operation timeout from benchmarks.json

### DIFF
--- a/templates/GLM-47-flash/benchmarks.json
+++ b/templates/GLM-47-flash/benchmarks.json
@@ -4,6 +4,7 @@
       "glm-47-flash-q4",
       "glm-47-flash-bf16"
     ],
+    "timeoutSeconds": 1200,
     "metrics": [
       {
         "key": "tokens_per_second",

--- a/templates/Gemma4/benchmarks.json
+++ b/templates/Gemma4/benchmarks.json
@@ -6,6 +6,7 @@
       "26b",
       "31b"
     ],
+    "timeoutSeconds": 1200,
     "metrics": [
       {
         "key": "tokens_per_second",

--- a/validation/schema.validation.js
+++ b/validation/schema.validation.js
@@ -45,6 +45,9 @@ const OpsOverrides = z
 const BenchmarkGroup = z
   .object({
     variants: z.array(z.string().min(1)).min(1),
+    // Max run time (seconds) for the benchmark ops; the node kills the op past
+    // this. Optional — the host manager falls back to its default when omitted.
+    timeoutSeconds: z.number().int().positive().optional(),
     metrics: z.array(Metric).min(1),
     // Op structure is validated by the kit's validateOps; here we only require objects.
     support_ops: z.array(z.object({}).passthrough()).min(1),


### PR DESCRIPTION
Add an optional `timeoutSeconds` to each benchmark group so the host manager can set the node's per-operation timeout from the template instead of relying on the hardcoded 300s default. Set Gemma4 and GLM-47-flash to 1200s (headroom for model load into VRAM + warmup + the benchmark run) and accept the field in the benchmarks.json validator.