### PR TITLE
fix: resolve benchmark server op ref + size Qwen3.6 bf16 timeouts

### DIFF
--- a/templates/Qwen3.5/job-definition-9b.json
+++ b/templates/Qwen3.5/job-definition-9b.json
@@ -8,7 +8,7 @@
   },
   "ops": [
     {
-      "id": "Qwen3-5-9b",
+      "id": "server",
       "type": "container/run",
       "args": {
         "gpu": true,

--- a/templates/Qwen3.6/benchmarks.json
+++ b/templates/Qwen3.6/benchmarks.json
@@ -4,7 +4,7 @@
       "27b",
       "35b-a3b"
     ],
-    "timeoutSeconds": 1200,
+    "timeoutSeconds": 1800,
     "metrics": [
       {
         "key": "tokens_per_second",
@@ -42,7 +42,7 @@
             "BASE_URL": "http://%%ops.server.host%%:11434",
             "DURATION": "100",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "300"
+            "WARMUP_REQUEST_TIMEOUT": "1200"
           }
         },
         "execution": {

--- a/templates/Qwen3.6/job-definition.json
+++ b/templates/Qwen3.6/job-definition.json
@@ -8,7 +8,7 @@
   },
   "ops": [
     {
-      "id": "Qwen3-6-35b-a3b",
+      "id": "server",
       "type": "container/run",
       "args": {
         "gpu": true,


### PR DESCRIPTION
## Why
PR #147 was merged at an earlier commit, so two fixes never landed on `main`. The live Qwen benchmark job-defs are still broken:

- `Qwen3.5/job-definition-9b.json` and `Qwen3.6/job-definition.json` name the model op `Qwen3-5-9b` / `Qwen3-6-35b-a3b`, but the benchmark op references `%%ops.server.host%%` → `Unresolved literal`, benchmark never reaches the model (empty results).
- The `qwen3.6:35b-a3b-bf16` (~71 GB) model can't load within the 300 s warmup / op timeout, so it's killed before producing results.

## Changes
- Name the model op **`server`** in the Qwen3.5 9b and Qwen3.6 35b-a3b job-definitions so `%%ops.server.host%%` resolves (Qwen3.6 27b already used `server`).
- Qwen3.6 group: `WARMUP_REQUEST_TIMEOUT` 300 → **1200**, operation `timeoutSeconds` 1200 → **1800** (op kill-timer stays above warmup + duration).

## Notes
- `timeoutSeconds` only takes effect once HM runs a template refresh so the operation is re-stamped.
- If ~1200 s warmup still isn't enough, the bf16 model is downloading in-band rather than loading from a cached resource — a separate fix.
- `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)