### PR TITLE
Shrink large benchmark tier and bump Ollama to 0.31.2

### DIFF
--- a/templates/GLM-47-flash/job-definition-GLM-16fp.json
+++ b/templates/GLM-47-flash/job-definition-GLM-16fp.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/GLM-47-flash/job-definition-GLM-q4.json
+++ b/templates/GLM-47-flash/job-definition-GLM-q4.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/GPT-OSS/job-definition-120b.json
+++ b/templates/GPT-OSS/job-definition-120b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/GPT-OSS/job-definition-20b.json
+++ b/templates/GPT-OSS/job-definition-20b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma3/job-definition-12b.json
+++ b/templates/Gemma3/job-definition-12b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma3/job-definition-27b.json
+++ b/templates/Gemma3/job-definition-27b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma3/job-definition-4b.json
+++ b/templates/Gemma3/job-definition-4b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-26b.json
+++ b/templates/Gemma4/job-definition-26b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-31b.json
+++ b/templates/Gemma4/job-definition-31b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-e2b.json
+++ b/templates/Gemma4/job-definition-e2b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-e4b.json
+++ b/templates/Gemma4/job-definition-e4b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/OpenClaw/job-definition-GLM-16fp.json
+++ b/templates/OpenClaw/job-definition-GLM-16fp.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.20.0",
+        "image": "ollama/ollama:0.31.2",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/OpenClaw/job-definition-GLM-q4.json
+++ b/templates/OpenClaw/job-definition-GLM-q4.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.20.0",
+        "image": "ollama/ollama:0.31.2",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/OpenClaw/job-definition-gpt-120b.json
+++ b/templates/OpenClaw/job-definition-gpt-120b.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.20.0",
+        "image": "ollama/ollama:0.31.2",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/OpenClaw/job-definition-gpt-20b.json
+++ b/templates/OpenClaw/job-definition-gpt-20b.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.20.0",
+        "image": "ollama/ollama:0.31.2",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/Qwen3.5/job-definition-27b.json
+++ b/templates/Qwen3.5/job-definition-27b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.5/job-definition-35b.json
+++ b/templates/Qwen3.5/job-definition-35b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.5/job-definition-9b.json
+++ b/templates/Qwen3.5/job-definition-9b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.6/README.md
+++ b/templates/Qwen3.6/README.md
@@ -1,15 +1,15 @@
 # Qwen 3.6
 
-Qwen 3.6 delivers substantial upgrades in agentic coding and thinking preservation over previous Qwen models. Served through Ollama, this template deploys the default open-weight `qwen3.6:35b-a3b` model with support for text and image input.
+Qwen 3.6 delivers substantial upgrades in agentic coding and thinking preservation over previous Qwen models. Served through Ollama, this template deploys the open-weight `qwen3.6:35b-a3b-q8_0` model with support for text and image input.
 
 ## Included Model
 
 ### 35B A3B
-- **Model Tag**: `qwen3.6:35b-a3b`
-- **Model Size**: 24 GB
+- **Model Tag**: `qwen3.6:35b-a3b-q8_0`
+- **Model Size**: 39 GB
 - **Context Length**: 256K tokens
 - **Modalities**: Text, Image
-- **VRAM Required**: ~26 GB
+- **VRAM Required**: ~45 GB
 - **Use Case**: Advanced coding, repository-level reasoning, and multimodal assistant workflows
 
 ## Highlights
@@ -34,7 +34,7 @@ The model is served on port 11434 with OpenAI-compatible endpoints:
 ```bash
 curl http://your-deployment-url:11434/api/chat \
   -d '{
-    "model": "qwen3.6:35b-a3b",
+    "model": "qwen3.6:35b-a3b-q8_0",
     "messages": [{"role": "user", "content": "Help me review this repository."}]
   }'
 ```

--- a/templates/Qwen3.6/info.json
+++ b/templates/Qwen3.6/info.json
@@ -13,7 +13,7 @@
     {
       "id": "35b-a3b",
       "name": "35B-A3B Model",
-      "description": "Qwen 3.6 35B-A3B MoE model, bf16 (71 GB, 256K context, Text + Image)",
+      "description": "Qwen 3.6 35B-A3B MoE model, q8_0 (39 GB, 256K context, Text + Image)",
       "job_definition": "job-definition.json"
     }
   ]

--- a/templates/Qwen3.6/job-definition-27b.json
+++ b/templates/Qwen3.6/job-definition-27b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.6/job-definition.json
+++ b/templates/Qwen3.6/job-definition.json
@@ -3,7 +3,7 @@
   "type": "container",
   "global": {
     "variables": {
-      "MODEL": "qwen3.6:35b-a3b-bf16"
+      "MODEL": "qwen3.6:35b-a3b-q8_0"
     }
   },
   "ops": [
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.20.0",
+        "image": "docker.io/ollama/ollama:0.31.2",
         "expose": [
           {
             "port": 11434,
@@ -39,7 +39,7 @@
   "meta": {
     "trigger": "dashboard",
     "system_requirements": {
-      "vram_total_mb": 76800
+      "vram_total_mb": 46080
     }
   }
 }


### PR DESCRIPTION
## Summary
- Replace the Qwen3.6 `35b-a3b-bf16` model (76.8GB VRAM) with the `q8_0` quantization (~46GB VRAM) as the "large" benchmark tier — bf16 was too big for the target GPU class. Tiers are now: small = Qwen3.5 9b (~9GB), mid = Qwen3.6 27b (~23GB), large = Qwen3.6 35b-a3b q8_0 (~46GB).
- Bump the `ollama/ollama` image from `0.20.0` to `0.31.2` across all Ollama-based templates (Gemma3, Gemma4, GLM-47-flash, GPT-OSS, OpenClaw, Qwen3.5, Qwen3.6).

## Test plan
- [x] `npm run validate` — all templates valid
- [x] `npm test` — 24/24 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)