### PR TITLE
fix: set big-model benchmark warmup timeout to 15 minutes

### DIFF
--- a/templates/Qwen3.6/benchmarks.json
+++ b/templates/Qwen3.6/benchmarks.json
@@ -42,7 +42,7 @@
             "BASE_URL": "http://%%ops.server.host%%:11434",
             "DURATION": "100",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "1200"
+            "WARMUP_REQUEST_TIMEOUT": "900"
           }
         },
         "execution": {


### PR DESCRIPTION
## What
Lower the Qwen3.6 benchmark group `WARMUP_REQUEST_TIMEOUT` from **1200s → 900s (15 minutes)**.

## Notes
- Applies to the Qwen3.6 group's `27b` and `35b-a3b` (q8_0) variants — they share one benchmark op, so the warmup timeout is per-group.
- Operation `timeoutSeconds` stays **1800** (still above warmup + `DURATION` 100), so the node kill-timer won't fire before the benchmark finishes.
- `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)