### PR TITLE
fix: right-size benchmark timeouts from real run data

### DIFF
--- a/templates/Qwen3.5/benchmarks.json
+++ b/templates/Qwen3.5/benchmarks.json
@@ -3,7 +3,7 @@
     "variants": [
       "9b"
     ],
-    "timeoutSeconds": 1200,
+    "timeoutSeconds": 600,
     "metrics": [
       {
         "key": "tokens_per_second",

--- a/templates/Qwen3.6/benchmarks.json
+++ b/templates/Qwen3.6/benchmarks.json
@@ -4,7 +4,7 @@
       "27b",
       "35b-a3b"
     ],
-    "timeoutSeconds": 1800,
+    "timeoutSeconds": 1200,
     "metrics": [
       {
         "key": "tokens_per_second",
@@ -42,7 +42,7 @@
             "BASE_URL": "http://%%ops.server.host%%:11434",
             "DURATION": "100",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "1200"
+            "WARMUP_REQUEST_TIMEOUT": "600"
           }
         },
         "execution": {


### PR DESCRIPTION
## What
Tune the benchmark timeouts to fit the actual workload (they were sized for the old 71 GB bf16 model; the big model is now `q8_0`, ~39 GB).

| Group | Before (warmup / op) | After (warmup / op) |
|-------|----------------------|---------------------|
| Qwen3.5 `9b` | 300 / 1200 | 300 / **600** |
| Qwen3.6 `27b` + `35b-a3b` | 1200 / 1800 | **600** / **1200** |

## Evidence
A successful `qwen3.5:9b` run on an RTX 4090: warmup request **47 s**, total op **~222 s** (container start ~70 s + warmup ~50 s + 100 s run). Old op-timeout of 1200 was ~5× the actual.

Each op `timeoutSeconds` stays above `WARMUP_REQUEST_TIMEOUT + DURATION(100) + container-start`, so a legitimate run is never cut short; hung ops just reap sooner than before.

Supersedes #150 (which only lowered the big-model warmup). `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)