### PR TITLE
fix: set MAX_WAIT_TIME so slow/big model loads aren't cut off at 300s

### DIFF
--- a/templates/Qwen3.5/benchmarks.json
+++ b/templates/Qwen3.5/benchmarks.json
@@ -41,7 +41,8 @@
             "BASE_URL": "http://%%ops.server.host%%:11434",
             "DURATION": "100",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "300"
+            "WARMUP_REQUEST_TIMEOUT": "300",
+            "MAX_WAIT_TIME": "600"
           }
         },
         "execution": {

--- a/templates/Qwen3.6/benchmarks.json
+++ b/templates/Qwen3.6/benchmarks.json
@@ -42,7 +42,8 @@
             "BASE_URL": "http://%%ops.server.host%%:11434",
             "DURATION": "100",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "1200"
+            "WARMUP_REQUEST_TIMEOUT": "300",
+            "MAX_WAIT_TIME": "1200"
           }
         },
         "execution": {


### PR DESCRIPTION
## Root cause
Benchmarks were failing across the board (prod DB analysis, 2026-07-20):
- `qwen3.6:35b-a3b`: **0% real results** — fails even on a 96 GB Pro 6000, `exit 1`, `OOMKilled=false`, every failure logging `RESULT:{"error":"Endpoint timeout","status":"failed","timeout_seconds":300}`.
- `9b`/`27b`: intermittent `exit 1` on slower consumer cards, same signature.

The llm-benchmark tool (`metric-containers/.../llm_benchmark.py:540`) polls `/v1/models` for the model for up to **`MAX_WAIT_TIME` (env, default 300 s)** — and the templates **never set it**. Any model not pulled+loaded+listed within 300 s fails with "Endpoint timeout". This is a **third timeout**, independent of `WARMUP_REQUEST_TIMEOUT` and the operation `timeout_seconds`, which is why earlier timeout tuning didn't help. Only ~4 runs were ever killed by the op timeout.

## Change
Set `MAX_WAIT_TIME` on each benchmark's env, keeping the invariant `timeout_seconds > MAX_WAIT_TIME + warmup + DURATION`:

| op | MAX_WAIT_TIME | WARMUP_REQUEST_TIMEOUT | DURATION | op timeout_seconds |
|----|---------------|------------------------|----------|--------------------|
| Qwen3.5 9b | **600** | 300 | 100 | 1200 |
| Qwen3.6 27b + 35b-a3b | **1200** | 1200 → **300** | 100 | 1800 |

(Qwen3.6 warmup dropped 1200→300 — it was never the bottleneck, and it keeps the op-timeout invariant.)

## Notes
- No image change — `MAX_WAIT_TIME` is already read by `nosana/llm-benchmark:0.0.2`.
- Failures that remain after this are genuinely slow nodes (can't pull+load in the allotted window) — an honest signal, not to be papered over by lowering thresholds.
- If 1200 s still isn't enough for the 46 GB `35b-a3b`, the real issue is an in-band 46 GB pull → pre-cache the model rather than grow the timeout further.
- `npm run validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)