### PR TITLE
fix: give bigger benchmarks more wait/warmup/duration

### DIFF
--- a/templates/Gemma4/benchmarks.json
+++ b/templates/Gemma4/benchmarks.json
@@ -3,7 +3,7 @@
     "variants": [
       "26b"
     ],
-    "timeoutSeconds": 1800,
+    "timeoutSeconds": 2400,
     "metrics": [
       {
         "key": "tokens_per_second",
@@ -39,10 +39,10 @@
           "gpu": true,
           "env": {
             "BASE_URL": "http://%%ops.server.host%%:11434",
-            "DURATION": "100",
+            "DURATION": "150",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "300",
-            "MAX_WAIT_TIME": "900"
+            "WARMUP_REQUEST_TIMEOUT": "420",
+            "MAX_WAIT_TIME": "1500"
           }
         },
         "execution": {

--- a/templates/Laguna-xs-2.1/benchmarks.json
+++ b/templates/Laguna-xs-2.1/benchmarks.json
@@ -3,7 +3,7 @@
     "variants": [
       "bf16"
     ],
-    "timeoutSeconds": 2400,
+    "timeoutSeconds": 4800,
     "metrics": [
       {
         "key": "tokens_per_second",
@@ -39,10 +39,10 @@
           "gpu": true,
           "env": {
             "BASE_URL": "http://%%ops.server.host%%:11434",
-            "DURATION": "100",
+            "DURATION": "200",
             "CONCURRENT_USERS": "1",
-            "WARMUP_REQUEST_TIMEOUT": "300",
-            "MAX_WAIT_TIME": "1500"
+            "WARMUP_REQUEST_TIMEOUT": "600",
+            "MAX_WAIT_TIME": "3600"
           }
         },
         "execution": {


### PR DESCRIPTION
## Why

The benchmark loads the model on the node before measuring. On a node that doesn't have the model cached yet, it must **pull + load within `MAX_WAIT_TIME`** (the endpoint-readiness window). For the bigger models the current windows are too tight for a cold pull on slower nodes, which shows up as the "no tokens returned" bucket in the fleet data:

- **laguna-bf16** (~67 GB) at `MAX_WAIT=1500` only succeeds above **~45 MB/s** on a cold pull → almost nothing scores on laguna today, so 80 GB / Pro-6000 markets fall back to gemma4-26b.
- **gemma4-26b** (~16 GB) at `MAX_WAIT=900` fails below **~18 MB/s** on a cold pull.

## Change

Bump wait + warmup and lengthen the measurement window for the two bigger tiers. **ornith-9b is unchanged** — 5.6 GB pulls comfortably in the existing window and its failures are OOM/crash, not timeouts.

| Model | \`timeoutSeconds\` | \`MAX_WAIT_TIME\` | \`WARMUP_REQUEST_TIMEOUT\` | \`DURATION\` |
|---|---|---|---|---|
| ornith-9b | 1200 *(unchanged)* | 600 | 300 | 100 |
| gemma4-26b | 1800 → **2400** | 900 → **1500** | 300 → **420** | 100 → **150** |
| laguna-bf16 | 2400 → **4800** | 1500 → **3600** | 300 → **600** | 100 → **200** |

Invariant preserved: \`timeoutSeconds > MAX_WAIT_TIME + WARMUP + DURATION + buffer\`.

## Note

Keeping laguna at bf16 (not q8_0) is deliberate. \`MAX_WAIT=3600\` covers a 67 GB cold pull down to ~20 MB/s; nodes on slower links will still time out on laguna, which is acceptable since the target there is 80 GB datacenter cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)