### PR TITLE
chore: bump llm-benchmark image to 0.0.3

### DIFF
--- a/templates/Gemma4/benchmarks.json
+++ b/templates/Gemma4/benchmarks.json
@@ -35,7 +35,7 @@
         "id": "benchmark",
         "type": "container/run",
         "args": {
-          "image": "nosana/llm-benchmark:0.0.2",
+          "image": "nosana/llm-benchmark:0.0.3",
           "gpu": true,
           "env": {
             "BASE_URL": "http://%%ops.server.host%%:11434",

--- a/templates/Laguna-xs-2.1/benchmarks.json
+++ b/templates/Laguna-xs-2.1/benchmarks.json
@@ -35,7 +35,7 @@
         "id": "benchmark",
         "type": "container/run",
         "args": {
-          "image": "nosana/llm-benchmark:0.0.2",
+          "image": "nosana/llm-benchmark:0.0.3",
           "gpu": true,
           "env": {
             "BASE_URL": "http://%%ops.server.host%%:11434",

--- a/templates/Ornith/benchmarks.json
+++ b/templates/Ornith/benchmarks.json
@@ -35,7 +35,7 @@
         "id": "benchmark",
         "type": "container/run",
         "args": {
-          "image": "nosana/llm-benchmark:0.0.2",
+          "image": "nosana/llm-benchmark:0.0.3",
           "gpu": true,
           "env": {
             "BASE_URL": "http://%%ops.server.host%%:11434",


### PR DESCRIPTION
Bumps the benchmark image `nosana/llm-benchmark:0.0.2` → `0.0.3` in all three LLM benchmarks (Ornith, Gemma4, Laguna).

## What 0.0.3 adds
The benchmark's endpoint poller (`wait_for_endpoint`) previously swallowed every polling error and, on timeout, emitted a bare `{"error":"Endpoint timeout"}`. 0.0.3 records **`poll_diag`** in the timeout RESULT — last `/v1/models` status, connection error, whether any model was listed, and a final `/api/tags` probe — so a failed run reports the actual cause:

- `connection error` → llm server never came up (resource/provisioning failure)
- `500` / empty → server up but the model never registered

No behaviour change on success. This is the visibility half of the "benchmarks that return no tokens" investigation; the resource-download retry that fixes most of those failures ships separately in the node CLI.

Image validated end-to-end on an RTX 4090 (ornith:9b, ~123 t/s) before publishing to `nosana/llm-benchmark:0.0.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)