### PR TITLE
Declare the benchmark pair from the operation that waits

### DIFF
--- a/templates/Gemma4/benchmarks.json
+++ b/templates/Gemma4/benchmarks.json
@@ -46,7 +46,10 @@
           }
         },
         "execution": {
-          "group": "llm-pair"
+          "group": "llm-pair",
+          "depends_on": [
+            "server"
+          ]
         },
         "results": {
           "tokens_per_second": "\"users_1_tokens_per_second_mean\":(-?[\\d.]+)",
@@ -58,9 +61,6 @@
     "ops_overrides": {
       "execution": {
         "group": "llm-pair",
-        "depends_on": [
-          "benchmark"
-        ],
         "stop_if_dependent_stops": true
       }
     }

--- a/templates/Laguna-s-2.1/benchmarks.json
+++ b/templates/Laguna-s-2.1/benchmarks.json
@@ -46,7 +46,10 @@
           }
         },
         "execution": {
-          "group": "llm-pair"
+          "group": "llm-pair",
+          "depends_on": [
+            "server"
+          ]
         },
         "results": {
           "tokens_per_second": "\"users_1_tokens_per_second_mean\":(-?[\\d.]+)",
@@ -58,9 +61,6 @@
     "ops_overrides": {
       "execution": {
         "group": "llm-pair",
-        "depends_on": [
-          "benchmark"
-        ],
         "stop_if_dependent_stops": true
       }
     }

--- a/templates/Ornith/benchmarks.json
+++ b/templates/Ornith/benchmarks.json
@@ -46,7 +46,10 @@
           }
         },
         "execution": {
-          "group": "llm-pair"
+          "group": "llm-pair",
+          "depends_on": [
+            "server"
+          ]
         },
         "results": {
           "tokens_per_second": "\"users_1_tokens_per_second_mean\":(-?[\\d.]+)",
@@ -58,9 +61,6 @@
     "ops_overrides": {
       "execution": {
         "group": "llm-pair",
-        "depends_on": [
-          "benchmark"
-        ],
         "stop_if_dependent_stops": true
       }
     }


### PR DESCRIPTION
The server carried `depends_on: ["benchmark"]`, which reads as the server waiting for the benchmark — the opposite of what the pair needs. It was written that way because the node's stop trigger only looked at the stopping operation's own `depends_on`.

The node now resolves dependents from either side, so this states it as it reads: the benchmark waits for the server, and the server declares only that its lifetime follows whatever depends on it.

**Depends on, in order:**
1. [kit] relaxed execution schema — allows the lifetime flag with no `depends_on` of its own
2. [node!38] resolves dependents from either side

Without both merged and released, template refresh rejects these files at validation.