### PR TITLE
chore: bump ollama to 0.32.6 in all job definitions

### DIFF
--- a/templates/GLM-47-flash/job-definition-GLM-16fp.json
+++ b/templates/GLM-47-flash/job-definition-GLM-16fp.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/GLM-47-flash/job-definition-GLM-q4.json
+++ b/templates/GLM-47-flash/job-definition-GLM-q4.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/GPT-OSS/job-definition-120b.json
+++ b/templates/GPT-OSS/job-definition-120b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/GPT-OSS/job-definition-20b.json
+++ b/templates/GPT-OSS/job-definition-20b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma3/job-definition-12b.json
+++ b/templates/Gemma3/job-definition-12b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma3/job-definition-27b.json
+++ b/templates/Gemma3/job-definition-27b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma3/job-definition-4b.json
+++ b/templates/Gemma3/job-definition-4b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-26b.json
+++ b/templates/Gemma4/job-definition-26b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-31b.json
+++ b/templates/Gemma4/job-definition-31b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-e2b.json
+++ b/templates/Gemma4/job-definition-e2b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Gemma4/job-definition-e4b.json
+++ b/templates/Gemma4/job-definition-e4b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Laguna-s-2.1/job-definition-q4_k_m.json
+++ b/templates/Laguna-s-2.1/job-definition-q4_k_m.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/OpenClaw/job-definition-GLM-16fp.json
+++ b/templates/OpenClaw/job-definition-GLM-16fp.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.31.2",
+        "image": "ollama/ollama:0.32.6",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/OpenClaw/job-definition-GLM-q4.json
+++ b/templates/OpenClaw/job-definition-GLM-q4.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.31.2",
+        "image": "ollama/ollama:0.32.6",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/OpenClaw/job-definition-gpt-120b.json
+++ b/templates/OpenClaw/job-definition-gpt-120b.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.31.2",
+        "image": "ollama/ollama:0.32.6",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/OpenClaw/job-definition-gpt-20b.json
+++ b/templates/OpenClaw/job-definition-gpt-20b.json
@@ -13,7 +13,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "ollama/ollama:0.31.2",
+        "image": "ollama/ollama:0.32.6",
         "entrypoint": [
           "/bin/sh",
           "/root/entrypoint/entrypoint.sh"

--- a/templates/Ornith/job-definition-9b.json
+++ b/templates/Ornith/job-definition-9b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.5/job-definition-27b.json
+++ b/templates/Qwen3.5/job-definition-27b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.5/job-definition-35b.json
+++ b/templates/Qwen3.5/job-definition-35b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.5/job-definition-9b.json
+++ b/templates/Qwen3.5/job-definition-9b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.6/job-definition-27b.json
+++ b/templates/Qwen3.6/job-definition-27b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,

--- a/templates/Qwen3.6/job-definition.json
+++ b/templates/Qwen3.6/job-definition.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.31.2",
+        "image": "docker.io/ollama/ollama:0.32.6",
         "expose": [
           {
             "port": 11434,


### PR DESCRIPTION
## Why

The `Laguna S 2.1 q4_k_m` benchmark has never produced a token on any node (0/5 nodes, all on `NVIDIA Pro 6000 (SOC2)` / 95 GB). Decoding the op states shows it is not a sizing or provisioning problem — the model downloads, ollama starts and reports `95.0 GiB` available, `/api/tags` returns 200, and then `llama-server` dies while loading:

```
error loading model: missing tensor 'blk.0.attn_g.weight'
llama_server: exiting due to model loading error
POST /v1/chat/completions -> 500
Warmup incomplete: only 0/2 successful
```

Identical blob (`sha256-948255a1…`), identical failure, on every node — deterministic, not flaky. The llama.cpp build inside `ollama/ollama:0.31.2` does not accept that model's tensor layout. `0.32.6` is the current stable release (2026-08-05).

Ruled out: VRAM (95 GB free on a 95 GB card), the timeout invariant (`MAX_WAIT_TIME 3600` + warmup 600 + `DURATION` 200 = 4400 < `timeoutSeconds` 4800), and provisioning — the earlier `Missing required resource` / interrupted-download failures are now at zero after the resource-manager fix.

## What

`docker.io/ollama/ollama:0.31.2` -> `0.32.6` in all 22 job definitions. Applied repo-wide rather than only to the three benchmarked models (Ornith, Gemma4, Laguna-s-2.1) so the fleet runs one ollama version.

## Validation

- `npm run validate` — all templates valid
- `node --test` — 24/24 pass

Once merged and the host-manager template refresh has run, the LLM metrics get invalidated fleetwide so every node re-benchmarks on the new image. Laguna is the one to watch: if `missing tensor` survives 0.32.6, the GGUF itself is incomplete and needs re-publishing.