### PR TITLE
feat: add Muse Glimmer 30B template

### DIFF
--- a/templates/Muse-Glimmer/README.md
+++ b/templates/Muse-Glimmer/README.md
@@ -1,0 +1,72 @@
+# Muse Glimmer
+
+Muse Glimmer is a 30-billion-parameter causal language model with a dedicated perception encoder, distilled from Muse Spark and built for autonomous agentic tasks on consumer hardware. It combines multi-step reasoning, tool use, multimodal understanding and failure recovery in a single model. Served through Ollama, this template deploys `muse-glimmer:30b` with an OpenAI-compatible API.
+
+## Included Model
+
+### 30B
+- **Model Tag**: `muse-glimmer:30b`
+- **Modalities**: Text, Image
+- **VRAM Required**: ~25 GB (24 GB-class GPUs and up)
+- **Use Case**: Agentic workflows, tool calling, coding assistants, screenshot and document understanding
+
+The `30b-mlx` tag is an Apple Silicon build and is not applicable to Nosana GPU nodes.
+
+## Highlights
+
+- **End-to-end agentic task completion**: strong results on DeepSearch QA, MCP-Atlas, 𝛕3-Bench and SWE-Bench
+- **Reliable tool use**: precise function-call schemas across extended workflows
+- **Multi-step reasoning**: coherent plans over long horizons
+- **Failure recovery**: diagnoses failed or unexpected tool results and retries instead of halting
+- **Multimodal input**: interleaved text and images through a dedicated perception encoder
+- **Scaffold compatibility**: works with OpenClaw, Hermes Agent and similar orchestration patterns
+- **Controllable effort**: selectable reasoning strengths to trade quality against speed
+- **Multilingual**: trained on data from more than 100 languages
+- **Automatic model download**: the model is pulled automatically on startup
+
+## Benchmarks
+
+Reported by Meta, compared with Gemma4-31B and Qwen3.6-27B (thinking mode):
+
+| Category | Benchmark | Muse Glimmer-30B | Gemma4-31B | Qwen3.6-27B |
+| --- | --- | --- | --- | --- |
+| General Agentic | MCP Atlas (Public) | 75.5 | 54.2 | 62.5 |
+| | DeepSearch QA | 74.6 | 61.7 | 71.1 |
+| | 𝛕3-Banking | 23.5 | 15.1 | 16.7 |
+| | WildClawBench | 47.6 | 37.6 | 43.2 |
+| | GDPVal-AA v2 | 953 | 811 | 1141 |
+| | Gaia2 | 43.3 | 36.4 | 40.0 |
+| | SkillsBench (with skills) | 44.3 | 32.4 | 46.6 |
+| | OSWorld-Verified | 65.9 | 58.5 | 75.6 |
+| Agentic Coding | SWE-Bench Pro | 51.2 | 36.9 | 50.2 |
+| | SWE-Bench Verified | 76.0 | 66.6 | 77.2 |
+| | TerminalBench 2.1 (with terminus2) | 51.7 | 43.4 | 60.7 |
+| | SciCode | 43.6 | 43.4 | 39.8 |
+| Multimodal | Charxiv Reasoning | 78.8 | 77.7 | 78.4 |
+| | ScreenSpot Pro | 75.4 | 75.9 | 76.1 |
+| | OmniDocBench v1.5 | 75.8 | 72.5 | 77.8 |
+| | MMMU Pro | 74 | 73 | 75 |
+| General Reasoning | IFBench | 77.0 | 76.0 | 70.8 |
+| | AIME 2026 | 94.7 | 89.2 | 94.1 |
+| | GPQA Diamond (AA) | 83.5 | 85.7 | 84.2 |
+| | HLE Text (AA) | 22.0 | 23.6 | 23.1 |
+| | AA-LCR | 80.0 | 68.3 | 73.3 |
+| | Beam128K | 65.1 | 58.2 | 63.0 |
+
+## Usage
+
+The model is served on port 11434 with OpenAI-compatible endpoints:
+
+- **Chat Completions**: `POST /v1/chat/completions`
+- **Generate**: `POST /api/generate`
+- **Model Info**: `GET /api/tags`
+
+### Example Request
+
+```bash
+curl http://your-deployment-url:11434/api/chat \
+  -d '{
+    "model": "muse-glimmer:30b",
+    "messages": [{"role": "user", "content": "Plan and run a three-step research task."}]
+  }'
+```

--- a/templates/Muse-Glimmer/info.json
+++ b/templates/Muse-Glimmer/info.json
@@ -1,0 +1,14 @@
+{
+  "id": "muse-glimmer",
+  "name": "Muse Glimmer",
+  "category": ["Official", "API", "LLM", "Ollama"],
+  "icon": "https://avatars.githubusercontent.com/u/69631?s=200&v=4",
+  "variants": [
+    {
+      "id": "30b",
+      "name": "30B Model",
+      "description": "Muse Glimmer 30B agentic model (Text + Image)",
+      "job_definition": "job-definition-30b.json"
+    }
+  ]
+}

--- a/templates/Muse-Glimmer/job-definition-30b.json
+++ b/templates/Muse-Glimmer/job-definition-30b.json
@@ -1,0 +1,45 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "global": {
+    "variables": {
+      "MODEL": "muse-glimmer:30b"
+    }
+  },
+  "ops": [
+    {
+      "id": "server",
+      "type": "container/run",
+      "args": {
+        "gpu": true,
+        "image": "docker.io/ollama/ollama:0.32.6",
+        "expose": [
+          {
+            "port": 11434,
+            "health_checks": [
+              {
+                "type": "http",
+                "path": "/api/tags",
+                "method": "GET",
+                "expected_status": 200,
+                "continuous": false
+              }
+            ]
+          }
+        ],
+        "resources": [
+          {
+            "type": "Ollama",
+            "model": "%%global.variables.MODEL%%"
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 25600
+    }
+  }
+}


### PR DESCRIPTION
Adds a template for `muse-glimmer:30b`, following the existing Ollama template pattern (Qwen3.6 / Gemma4).

Files:
- `info.json` — id `muse-glimmer`, categories Official/API/LLM/Ollama, single `30b` variant
- `job-definition-30b.json` — `ollama/ollama:0.32.6`, Ollama resource `muse-glimmer:30b`, port 11434 with the `/api/tags` health check, `vram_total_mb: 25600`
- `README.md` — description, highlights, benchmark table, usage

Notes:
- VRAM is set to the Gemma4-31B tier (25600 MB) as the closest-size reference; happy to adjust once measured.
- The icon is the Meta GitHub avatar for now — can be swapped for a local asset like Laguna-s-2.1 does.
- No `benchmarks.json`; the benchmark set looks curated per GPU tier, so I left it out.

`npm run validate` passes.