### PR TITLE
fix: pin Muse Glimmer to ollama 0.32.9

### DIFF
--- a/templates/Muse-Glimmer/README.md
+++ b/templates/Muse-Glimmer/README.md
@@ -5,12 +5,14 @@ Muse Glimmer is a 30-billion-parameter causal language model with a dedicated pe
 ## Included Model
 
 ### 30B
-- **Model Tag**: `muse-glimmer:30b`
+- **Model Tag**: `muse-glimmer:30b` (27.9B parameters, Q4_K_M)
+- **Model Size**: 18.2 GB
+- **Context Length**: 128K tokens
 - **Modalities**: Text, Image
-- **VRAM Required**: ~25 GB (24 GB-class GPUs and up)
+- **VRAM Required**: ~18 GB at 32K context (24 GB-class GPUs and up)
 - **Use Case**: Agentic workflows, tool calling, coding assistants, screenshot and document understanding
 
-The `30b-mlx` tag is an Apple Silicon build and is not applicable to Nosana GPU nodes.
+NVIDIA support for this architecture landed in Ollama 0.32.8, so the image is pinned above the 0.32.6 used by the other templates; 0.32.9 also carries a fix in the function-calling parser. The `30b-mlx` tag is an Apple Silicon build and is not applicable to Nosana GPU nodes.
 
 ## Highlights
 

--- a/templates/Muse-Glimmer/info.json
+++ b/templates/Muse-Glimmer/info.json
@@ -7,7 +7,7 @@
     {
       "id": "30b",
       "name": "30B Model",
-      "description": "Muse Glimmer 30B agentic model (Text + Image)",
+      "description": "Muse Glimmer 30B agentic model, q4_K_M (18 GB, 128K context, Text + Image)",
       "job_definition": "job-definition-30b.json"
     }
   ]

--- a/templates/Muse-Glimmer/job-definition-30b.json
+++ b/templates/Muse-Glimmer/job-definition-30b.json
@@ -12,7 +12,7 @@
       "type": "container/run",
       "args": {
         "gpu": true,
-        "image": "docker.io/ollama/ollama:0.32.6",
+        "image": "docker.io/ollama/ollama:0.32.9",
         "expose": [
           {
             "port": 11434,
@@ -39,7 +39,7 @@
   "meta": {
     "trigger": "dashboard",
     "system_requirements": {
-      "vram_total_mb": 25600
+      "vram_total_mb": 23552
     }
   }
 }


### PR DESCRIPTION
Follow-up to #161, which merged before this fix was pushed — `main` currently ships a Muse Glimmer template that cannot serve the model.

Tested against a live deployment on an RTX 4090. The model pulls fine, but every inference request 500s on `ollama/ollama:0.32.6`:

```
llama_model_load: error loading model: unknown model architecture: 'muse-glimmer'
mtmd_get_memory_usage: error: Failed to load CLIP model from .../sha256-f48b4523...
```

NVIDIA/AMD support for this architecture landed in ollama **0.32.8** (0.32.7 was MLX/Apple Silicon only), and **0.32.9** adds a fix for a boundary condition in the Muse Glimmer function-calling parser.

Changes:
- image `0.32.6` → `0.32.9`
- `vram_total_mb` 25600 → 23552 — the server logs report `predicted_vram=18.2 GiB` against `available_vram=23.0 GiB` at the default 32K context, so it fits a 4090; 25600 was a guess copied from the Gemma4-31B tier
- README/info.json facts corrected from live `/api/tags`: 27.9B params, Q4_K_M, 18.2 GB, 131072 context

Note: this template must stay above 0.32.6, so a future repo-wide ollama bump shouldn't sweep it downward.

`npm run validate` passes.