### PR TITLE
feat: add MiniMax Music 3 and MiniMax H3 templates

### DIFF
--- a/dockerfiles/Dockerfile.comfyui
+++ b/dockerfiles/Dockerfile.comfyui
@@ -3,33 +3,28 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_PREFER_BINARY=1
 ENV ROOT=/comfyui
 ENV NVIDIA_VISIBLE_DEVICES=all
+
+# Pinned so an image tag always maps to one ComfyUI release; model support is
+# tied to the release, e.g. MiniMax Music 3 needs >= 0.33.0.
+ARG COMFYUI_VERSION=v0.33.2
+
+# build-essential: triton (via comfy-kitchen) JIT-compiles CUDA driver shims at
+# runtime and fails at import without a C compiler.
 RUN apt-get update && apt-get install -y \
     git \
+    build-essential \
     ffmpeg \
     libgl1-mesa-dev \
     libglib2.0-0 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /
-RUN git clone https://github.com/comfyanonymous/ComfyUI.git ${ROOT}
+RUN git clone --depth 1 --branch ${COMFYUI_VERSION} https://github.com/comfyanonymous/ComfyUI.git ${ROOT}
 WORKDIR ${ROOT}
-RUN git checkout master
-RUN pip install --no-cache-dir --disable-pip-version-check \
-    transformers==4.44.0 \
-    tokenizers==0.19.1 \
-    safetensors==0.4.3 \
-    einops==0.8.0 \
-    scipy==1.13.1 \
-    aiohttp==3.9.5 \
-    Pillow \
-    PyYAML \
-    tqdm \
-    psutil
-RUN pip install --no-cache-dir torchsde sentencepiece kornia spandrel soundfile
-RUN pip install --no-cache-dir comfyui-frontend-package comfyui-workflow-templates comfyui-embedded-docs
-RUN pip install --no-cache-dir pydantic-settings alembic av
-RUN pip install --no-cache-dir --no-deps "comfy-kitchen>=0.2.5"
+# torch/torchvision/torchaudio come from the base image; the requirements list
+# them unpinned, so they stay as installed.
+RUN pip install --no-cache-dir --disable-pip-version-check -r requirements.txt
 RUN cd custom_nodes && \
-    git clone https://github.com/ltdrdata/ComfyUI-Manager.git
+    git clone --depth 1 https://github.com/ltdrdata/ComfyUI-Manager.git
 EXPOSE 8188
 CMD ["python", "main.py", "--listen", "0.0.0.0", "--port", "8188"]

--- a/templates/MiniMax-H3/README.md
+++ b/templates/MiniMax-H3/README.md
@@ -1,0 +1,123 @@
+# MiniMax H3 Video
+
+Open-weight video generation in ComfyUI. MiniMax H3 generates **video and its
+soundtrack in one pass** — a single sampling run produces a joint audio/video
+latent, so the sound belongs to the motion instead of being dubbed onto it.
+
+Default output is 1344×768, 124 frames at 24 fps (~5 s), with 32 kHz stereo
+audio. The frame count snaps to the model's 17k+5 grid; the trained range is
+roughly 124–362 frames.
+
+## Variants
+
+Two tasks, each for a GPU class:
+
+| Variant | Task | Text encoder | Requires |
+|---|---|---|---|
+| Image to Video (32 GB) | prompt + optional first/last keyframe | Qwen3-VL 32B nvfp4 | 32 GB, Blackwell |
+| Image to Video (80 GB) | prompt + optional first/last keyframe | Qwen3-VL 32B int8 | 80 GB |
+| Reference to Video (32 GB) | reference images drive identity | Qwen3-VL 32B nvfp4 | 32 GB, Blackwell |
+| Reference to Video (80 GB) | reference images drive identity | Qwen3-VL 32B int8 | 80 GB |
+
+The nvfp4 encoder needs Blackwell hardware (RTX 5090, RTX Pro 6000). The 80 GB
+variants use the int8 encoder, which runs on any architecture but needs the
+bigger card to sit beside the diffusion model.
+
+With no keyframe and no reference image, both tasks are plain text-to-video.
+
+## Measured on an RTX 5090 (32 GB)
+
+Image-to-video variant, fp8 diffusion model + nvfp4 encoder:
+
+| Run | Peak VRAM | Time |
+|---|---|---|
+| 832×480, 124 frames, 8 steps, cfg 1.0 | 27.0 GB | ~1 min |
+| 1344×768, 124 frames, 8 steps, cfg 1.0 | 27.2 GB | ~3.5 min |
+| 1344×768, 124 frames, first_frame supplied | 27.3 GB | ~3.5 min |
+| 1344×768, 124 frames, 30 steps, cfg 4.0 | 27.3 GB | ~20 min |
+
+VRAM is dominated by the 21 GB diffusion model, so resolution, length and step
+count move the peak far less than you would expect — every run above lands
+within 300 MB of the others. What they change is time: cfg above 1.0 evaluates
+the model twice per step, so 30 steps at cfg 4.0 costs roughly six times an
+8-step run at cfg 1.0.
+
+And on an RTX Pro 6000 (96 GB), the 80 GB variant with the 4-step turbo LoRA:
+
+| Run | Peak VRAM | Time |
+|---|---|---|
+| 1344×768, 124 frames, 4 steps, turbo LoRA | 52.6 GB | ~2 min |
+
+## The turbo LoRA needs the 80 GB variants
+
+MiniMax publishes 4-step turbo LoRAs, and they are a large speed win — but
+applying a LoRA to fp8 weights makes ComfyUI materialise a dequantized copy of
+the model. On a 32 GB card that runs out of memory during model load, at *any*
+resolution, including 512×288. The 32 GB variants therefore do not ship the
+LoRA at all; use plain sampling settings there.
+
+## Usage
+
+1. Open ComfyUI on port 8188.
+2. Build the graph. There is no bundled workflow template for the local
+   weights — the templates named `api_minimax_h3_*` in ComfyUI call MiniMax's
+   cloud API instead of these files:
+
+   ```
+   UNETLoader ─────────────► ModelSamplingMiniMaxH3 ──┐
+   CLIPLoader (type minimax) ─┐                       ├─► KSampler ─┬─► VAEDecode (video VAE) ──┐
+   VAELoader (video VAE) ─────┼─► MiniMax H3          │             │                           ├─► CreateVideo (24 fps) ─► SaveVideo
+   VAELoader (audio VAE) ─────┘   Image to Video ─────┤             └─► VAEDecodeAudio (audio VAE) ┘
+                                    │  positive ──────┤
+                                    └► ConditioningZeroOut ─► negative
+                                       LATENT ────────┘
+   ```
+
+3. Fill in the prompt, queue it.
+
+Both decoders read the *same* sampled latent: `VAEDecode` with the video VAE
+unwraps the video half, `VAEDecodeAudio` with the audio VAE takes the audio
+half. Feed both into `CreateVideo` at 24 fps to get a file with sound.
+
+`UNETLoader` must stay on `weight_dtype: default`. Forcing `fp8_e4m3fn` makes
+the quantized kernels reject the weights (`No backend can handle
+'rms_rope_split_half_'`).
+
+### Sampler settings
+
+| Setup | steps | cfg |
+|---|---|---|
+| 32 GB variants (no LoRA) | 8 for a quick look, 30 for quality | 1.0 at 8 steps, ~4.0 at 30 |
+| 80 GB variants with turbo LoRA | 4 | 1.0 |
+
+The 4-step turbo path on an 80 GB card is both the fastest and the cheapest
+route to a finished clip — ~2 min against ~20 min for 30 steps on a 5090.
+
+`ModelSamplingMiniMaxH3` sets the video and audio flow shifts together
+(defaults 12.0 / 3.0). The DiT derives the audio schedule from the video one,
+so set shifts on this node rather than patching sampling elsewhere.
+
+## Reference-to-video prompting
+
+The reference node presents its inputs to the text encoder as numbered tags,
+and the prompt refers to them the same way: `<Picture 1>`, `<Video 1>`,
+`<Audio 1>`, numbered per type from 1. `ref_image_size: max` gives the best
+identity fidelity at a 2048 px short edge, but reference tokens ride through
+every sampling step, so it is markedly slower than `match`.
+
+## Weights
+
+From [Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3):
+
+| File | Location | Size |
+|---|---|---|
+| `minimax_h3_fl2va_pruned_fp8_scaled.safetensors` (i2v) | `models/diffusion_models/` | 21 GB |
+| `minimax_h3_ref2va_pruned_fp8_scaled.safetensors` (ref2v) | `models/diffusion_models/` | 21 GB |
+| `qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors` (32 GB variants) | `models/text_encoders/` | 16 GB |
+| `qwen3vl_32b_minimax_h3_int8_convrot.safetensors` (80 GB variants) | `models/text_encoders/` | 27 GB |
+| `minimax_h3_video_vae_fp16.safetensors` | `models/vae/` | 5.2 GB |
+| `minimax_h3_audio_vae_fp32.safetensors` | `models/vae/` | 0.6 GB |
+| 4-step turbo LoRA (80 GB variants only) | `models/loras/` | 2.0 GB |
+
+Expect a long first start: 44–55 GB has to reach the node before ComfyUI comes
+up.

--- a/templates/MiniMax-H3/README.md
+++ b/templates/MiniMax-H3/README.md
@@ -42,6 +42,12 @@ within 300 MB of the others. What they change is time: cfg above 1.0 evaluates
 the model twice per step, so 30 steps at cfg 4.0 costs roughly six times an
 8-step run at cfg 1.0.
 
+Reference-to-video, one reference image, same node and settings:
+
+| Run | Peak VRAM | Time |
+|---|---|---|
+| 1344×768, 124 frames, 8 steps, 1 ref image | 26.7 GB | ~3.5 min |
+
 And on an RTX Pro 6000 (96 GB), the 80 GB variant with the 4-step turbo LoRA:
 
 | Run | Peak VRAM | Time |
@@ -104,6 +110,17 @@ and the prompt refers to them the same way: `<Picture 1>`, `<Video 1>`,
 `<Audio 1>`, numbered per type from 1. `ref_image_size: max` gives the best
 identity fidelity at a 2048 px short edge, but reference tokens ride through
 every sampling step, so it is markedly slower than `match`.
+
+Driving this node over the API: the reference inputs are autogrow groups, so
+they are nested under the group name rather than passed flat. `ref_image_1` as
+a top-level input is rejected with `unexpected keyword argument`; it belongs
+inside `ref_images`:
+
+```json
+"ref_images": { "ref_image_1": ["14", 0] }
+```
+
+The same holds for `ref_videos`, `ref_video_audios` and `ref_audios`.
 
 ## Weights
 

--- a/templates/MiniMax-H3/info.json
+++ b/templates/MiniMax-H3/info.json
@@ -1,0 +1,37 @@
+{
+  "id": "minimax-h3",
+  "name": "MiniMax H3 Video",
+  "category": [
+    "Official",
+    "Web UI",
+    "API",
+    "Video Generation"
+  ],
+  "icon": "https://framerusercontent.com/images/3cNQMWKzIhIrQ5KErBm7dSmbd2w.png",
+  "variants": [
+    {
+      "id": "i2v-32gb",
+      "name": "Image to Video (32 GB)",
+      "description": "Keyframe or text to video with audio, fp8 model + nvfp4 encoder (Blackwell, no turbo LoRA)",
+      "job_definition": "job-definition-i2v-32gb.json"
+    },
+    {
+      "id": "i2v-80gb",
+      "name": "Image to Video (80 GB)",
+      "description": "Keyframe or text to video with audio, fp8 model + int8 encoder, 4-step turbo LoRA",
+      "job_definition": "job-definition-i2v-80gb.json"
+    },
+    {
+      "id": "ref2v-32gb",
+      "name": "Reference to Video (32 GB)",
+      "description": "Reference images drive identity, fp8 model + nvfp4 encoder (Blackwell, no turbo LoRA)",
+      "job_definition": "job-definition-ref2v-32gb.json"
+    },
+    {
+      "id": "ref2v-80gb",
+      "name": "Reference to Video (80 GB)",
+      "description": "Reference images drive identity, fp8 model + int8 encoder, 4-step turbo LoRA",
+      "job_definition": "job-definition-ref2v-80gb.json"
+    }
+  ]
+}

--- a/templates/MiniMax-H3/job-definition-i2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-32gb.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "MiniMaxH3-i2v-comfy",
+      "args": {
+        "image": "docker.io/nosana/comfyui:2.0.9",
+        "expose": 8188,
+        "gpu": true,
+        "resources": [
+          {
+            "type": "HF",
+            "target": "/comfyui/models/diffusion_models/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "diffusion_models/minimax_h3_fl2va_pruned_fp8_scaled.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/text_encoders/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/vae/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "vae/minimax_h3_video_vae_fp16.safetensors",
+              "vae/minimax_h3_audio_vae_fp32.safetensors"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 30720
+    }
+  }
+}

--- a/templates/MiniMax-H3/job-definition-i2v-80gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-80gb.json
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "MiniMaxH3-i2v-comfy",
+      "args": {
+        "image": "docker.io/nosana/comfyui:2.0.9",
+        "expose": 8188,
+        "gpu": true,
+        "resources": [
+          {
+            "type": "HF",
+            "target": "/comfyui/models/diffusion_models/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "diffusion_models/minimax_h3_fl2va_pruned_fp8_scaled.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/text_encoders/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "text_encoders/qwen3vl_32b_minimax_h3_int8_convrot.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/vae/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "vae/minimax_h3_video_vae_fp16.safetensors",
+              "vae/minimax_h3_audio_vae_fp32.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/loras/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "loras/minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 73728
+    }
+  }
+}

--- a/templates/MiniMax-H3/job-definition-ref2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-32gb.json
@@ -1,0 +1,48 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "MiniMaxH3-ref2v-comfy",
+      "args": {
+        "image": "docker.io/nosana/comfyui:2.0.9",
+        "expose": 8188,
+        "gpu": true,
+        "resources": [
+          {
+            "type": "HF",
+            "target": "/comfyui/models/diffusion_models/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "diffusion_models/minimax_h3_ref2va_pruned_fp8_scaled.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/text_encoders/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/vae/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "vae/minimax_h3_video_vae_fp16.safetensors",
+              "vae/minimax_h3_audio_vae_fp32.safetensors"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 30720
+    }
+  }
+}

--- a/templates/MiniMax-H3/job-definition-ref2v-80gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-80gb.json
@@ -1,0 +1,56 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "MiniMaxH3-ref2v-comfy",
+      "args": {
+        "image": "docker.io/nosana/comfyui:2.0.9",
+        "expose": 8188,
+        "gpu": true,
+        "resources": [
+          {
+            "type": "HF",
+            "target": "/comfyui/models/diffusion_models/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "diffusion_models/minimax_h3_ref2va_pruned_fp8_scaled.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/text_encoders/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "text_encoders/qwen3vl_32b_minimax_h3_int8_convrot.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/vae/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "vae/minimax_h3_video_vae_fp16.safetensors",
+              "vae/minimax_h3_audio_vae_fp32.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/loras/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "loras/minimax_h3_ref2v_turbo_4step_v0.1_comfyui_bf16.safetensors"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 73728
+    }
+  }
+}

--- a/templates/MiniMax-Music-3/README.md
+++ b/templates/MiniMax-Music-3/README.md
@@ -1,0 +1,74 @@
+# MiniMax Music 3
+
+Open-weight music generation in ComfyUI. Give it lyrics and a description of the
+sound, and it renders a full song — intro / verse / chorus / bridge / outro —
+in stereo, up to 5 minutes long.
+
+## Model
+
+MiniMax Music 3 is a hybrid architecture: an 8B LLM (built on Qwen3-8B) handles
+long-range song structure, a 0.6B LLM fills in frame-level acoustic detail, and
+a flow-matching + Flow-VAE stage turns the combined hidden states into audio
+rather than decoding straight from tokens — which is what keeps longer tracks
+coherent instead of drifting.
+
+Weights are pulled from [Comfy-Org/MiniMax-Music-3](https://huggingface.co/Comfy-Org/MiniMax-Music-3):
+
+| File | Location | Size |
+|---|---|---|
+| `minimax_music3_dit_fp16.safetensors` | `models/diffusion_models/` | 4.9 GB |
+| `minimax_music3_text_encoder_pruned_int8_convrot.safetensors` | `models/text_encoders/` | 9.2 GB |
+| `minimax_music3_dav.safetensors` | `models/vae/` | 0.2 GB |
+
+- **VRAM Required**: 24 GB (peak ~14.5 GB on a 4090 at the default 120 s target)
+- **Web UI**: ComfyUI on port 8188
+- **Speed**: ~3 min for a 30 s song, ~5 min for a 2 min song, on a single 4090
+
+The image pins ComfyUI v0.33.2; MiniMax Music 3 nodes were added in 0.33.0.
+
+## Usage
+
+1. Open the ComfyUI web interface on port 8188.
+2. Load the built-in template: **Workflow → Browse Templates → Audio → MiniMax Music 3**
+   (the workflow is also at
+   [workflow_templates](https://github.com/Comfy-Org/workflow_templates/blob/main/templates/audio_minimax_music_3.json)).
+   The model files it expects are the ones this template downloads.
+3. Fill in **Caption** and **Lyrics**, set `max_duration`, and queue the prompt.
+
+## Writing the prompt
+
+**Lyrics** carry the structure. Section tags are the only executable structural
+instruction — the lyric text itself only conveys mood:
+
+```
+[Intro] [Verse] [Pre-Chorus] [Chorus] [Post-Chorus] [Bridge] [Instrumental] [Solo] [Outro]
+```
+
+**Caption** describes the sound. Plain prose works, but the model responds best
+to a structured caption in three sections:
+
+- **Global Metadata** — genre, BPM, key, emotional arc, production profile.
+- **Vocal Details** — gender, timbre, harmony, backing vocals, effects.
+- **Arrangement** — instruments, how they evolve section to section, groove,
+  bass, percussion, spatial effects.
+
+MiniMax publishes a caption-rewriting guide at
+[MiniMax-AI/MiniMax-Music3](https://github.com/MiniMax-AI/MiniMax-Music3).
+
+## Parameters
+
+| Parameter | Description |
+|---|---|
+| `max_duration` | Upper bound on length in seconds (default 120, up to 360 on the node). The model can and does end a song earlier when the lyrics run out. |
+| `seed` | Fix it to reproduce a take, change it for a different one. |
+| `tiled_decode` | Decodes the audio VAE in overlapping tiles to cut VRAM on long songs, at a small risk of seams. Off gives the best quality when VRAM allows. |
+
+## Notes
+
+- Output is written by `SaveAudioAdvanced` (MP3 by default; FLAC and Opus are
+  available on the node) and downloadable from the ComfyUI UI.
+- The same graph runs headless over the ComfyUI API on `/prompt`, so the
+  template works as a music-generation backend as well as a UI.
+- For a lower-VRAM run, swap the diffusion model for
+  `minimax_music3_dit_int8_convrot.safetensors` (2.5 GB) via ComfyUI-Manager or
+  the model manager, and enable tiled decode.

--- a/templates/MiniMax-Music-3/info.json
+++ b/templates/MiniMax-Music-3/info.json
@@ -1,6 +1,10 @@
 {
   "id": "minimax-music3",
   "name": "MiniMax Music 3",
-  "category": ["Web UI", "API"],
+  "category": [
+    "Official",
+    "Web UI",
+    "API"
+  ],
   "icon": "https://framerusercontent.com/images/3cNQMWKzIhIrQ5KErBm7dSmbd2w.png"
 }

--- a/templates/MiniMax-Music-3/info.json
+++ b/templates/MiniMax-Music-3/info.json
@@ -1,0 +1,6 @@
+{
+  "id": "minimax-music3",
+  "name": "MiniMax Music 3",
+  "category": ["Web UI", "API"],
+  "icon": "https://framerusercontent.com/images/3cNQMWKzIhIrQ5KErBm7dSmbd2w.png"
+}

--- a/templates/MiniMax-Music-3/job-definition.json
+++ b/templates/MiniMax-Music-3/job-definition.json
@@ -1,0 +1,47 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "MiniMaxMusic3-comfy",
+      "args": {
+        "image": "docker.io/nosana/comfyui:2.0.9",
+        "expose": 8188,
+        "gpu": true,
+        "resources": [
+          {
+            "type": "HF",
+            "target": "/comfyui/models/diffusion_models/",
+            "repo": "Comfy-Org/MiniMax-Music-3",
+            "files": [
+              "diffusion_models/minimax_music3_dit_fp16.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/text_encoders/",
+            "repo": "Comfy-Org/MiniMax-Music-3",
+            "files": [
+              "text_encoders/minimax_music3_text_encoder_pruned_int8_convrot.safetensors"
+            ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/vae/",
+            "repo": "Comfy-Org/MiniMax-Music-3",
+            "files": [
+              "vae/minimax_music3_dav.safetensors"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 23552
+    }
+  }
+}


### PR DESCRIPTION
Two ComfyUI templates for MiniMax's open-weight models, sharing one image bump.

## MiniMax Music 3 — `templates/MiniMax-Music-3`

Lyrics with section tags plus a structured caption in, a full song out. Weights from [Comfy-Org/MiniMax-Music-3](https://huggingface.co/Comfy-Org/MiniMax-Music-3) (fp16 DiT, pruned int8 text encoder, DAV VAE).

Verified on an `nvidia-4090` node, driven headless over the ComfyUI `/prompt` API:

| Run | Result |
|---|---|
| `max_duration=30` | success, ~3 min, 30.0 s stereo MP3 |
| `max_duration=120` | success, ~5 min, song self-terminated at 57 s |
| Peak VRAM | 14.5 GB — fits the 23552 MB tier |

## MiniMax H3 — `templates/MiniMax-H3`

Video **and its soundtrack in one sampling pass** — a joint audio/video latent, decoded by the video VAE and the audio VAE and muxed at 24 fps. Four variants: image-to-video and reference-to-video, each for a 32 GB Blackwell card (nvfp4 encoder) and an 80 GB card (int8 encoder).

Verified at 1344x768, 124 frames (~5 s):

| Node | Setup | Peak VRAM | Time |
|---|---|---|---|
| RTX 5090 (32 GB) | 8 steps, cfg 1.0 | 27.2 GB | ~3.5 min |
| RTX 5090 | first_frame supplied | 27.3 GB | ~3.5 min |
| RTX 5090 | 30 steps, cfg 4.0 | 27.3 GB | ~20 min |
| RTX Pro 6000 (96 GB) | 4 steps + turbo LoRA | 52.6 GB | ~2 min |
| RTX 5090 | reference-to-video, 1 ref image, 8 steps | 26.7 GB | ~3.5 min |

All four variants are covered: both diffusion models and both text encoders have run on a node.