### PR TITLE
feat: ship the turbo LoRA on the 32 GB MiniMax H3 variants

### DIFF
--- a/templates/MiniMax-H3/README.md
+++ b/templates/MiniMax-H3/README.md
@@ -43,19 +43,23 @@ Both decoders read the same sampled latent — `VAEDecode` takes the video half,
 `VAEDecodeAudio` the audio half. Feed both into `CreateVideo` for a file with
 sound.
 
+All variants ship the matching 4-step turbo LoRA — chain
+`UNETLoader → LoraLoaderModelOnly → ModelSamplingMiniMaxH3`:
+
 | Setup | steps | cfg |
 |---|---|---|
-| 32 GB variants (no LoRA) | 8 for a quick look, 30 for quality | 1.0 at 8 steps, ~4.0 at 30 |
-| 80 GB variants with turbo LoRA | 4 | 1.0 |
+| Turbo LoRA | 4 | 1.0 |
+| Without the LoRA | 8 for a quick look, 30 for quality | 1.0 at 8 steps, ~4.0 at 30 |
 
 cfg above 1.0 evaluates the model twice per step, so steps and cfg together
 drive the run time.
 
 ## Notes
 
-- **The 32 GB variants ship no turbo LoRA.** Applying a LoRA to fp8 weights
-  makes ComfyUI materialise a dequantized copy of the model, which runs out of
-  memory during load on a 32 GB card at any resolution.
+- Applying a LoRA to fp8 weights makes ComfyUI materialise a dequantized copy
+  of the model. This fits a 32 GB card only because the CUDA 13 image enables
+  ComfyUI's DynamicVRAM; on a cu128 image the same graph OOMs during load at
+  any resolution.
 - Keep `UNETLoader` on `weight_dtype: default`; forcing `fp8_e4m3fn` makes the
   quantized kernels reject the weights.
 - `ModelSamplingMiniMaxH3` sets the video and audio flow shifts together
@@ -79,4 +83,4 @@ From [Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3):
 | `qwen3vl_32b_minimax_h3_int8_convrot.safetensors` (80 GB) | `models/text_encoders/` | 27 GB |
 | `minimax_h3_video_vae_fp16.safetensors` | `models/vae/` | 5.2 GB |
 | `minimax_h3_audio_vae_fp32.safetensors` | `models/vae/` | 0.6 GB |
-| 4-step turbo LoRA (80 GB variants only) | `models/loras/` | 2.0 GB |
+| 4-step turbo LoRA for the matching task | `models/loras/` | 2.0 GB |

--- a/templates/MiniMax-H3/info.json
+++ b/templates/MiniMax-H3/info.json
@@ -12,7 +12,7 @@
     {
       "id": "i2v-32gb",
       "name": "Image to Video (32 GB)",
-      "description": "Keyframe or text to video with audio, fp8 model + nvfp4 encoder (Blackwell, no turbo LoRA)",
+      "description": "Keyframe or text to video with audio, fp8 model + nvfp4 encoder (Blackwell), 4-step turbo LoRA",
       "job_definition": "job-definition-i2v-32gb.json"
     },
     {
@@ -24,7 +24,7 @@
     {
       "id": "ref2v-32gb",
       "name": "Reference to Video (32 GB)",
-      "description": "Reference images drive identity, fp8 model + nvfp4 encoder (Blackwell, no turbo LoRA)",
+      "description": "Reference images drive identity, fp8 model + nvfp4 encoder (Blackwell), 4-step turbo LoRA",
       "job_definition": "job-definition-ref2v-32gb.json"
     },
     {

--- a/templates/MiniMax-H3/job-definition-i2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-32gb.json
@@ -34,6 +34,14 @@
               "vae/minimax_h3_video_vae_fp16.safetensors",
               "vae/minimax_h3_audio_vae_fp32.safetensors"
             ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/loras/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "loras/minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors"
+            ]
           }
         ]
       }

--- a/templates/MiniMax-H3/job-definition-ref2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-32gb.json
@@ -34,6 +34,14 @@
               "vae/minimax_h3_video_vae_fp16.safetensors",
               "vae/minimax_h3_audio_vae_fp32.safetensors"
             ]
+          },
+          {
+            "type": "HF",
+            "target": "/comfyui/models/loras/",
+            "repo": "Comfy-Org/MiniMax-H3",
+            "files": [
+              "loras/minimax_h3_ref2v_turbo_4step_v0.1_comfyui_bf16.safetensors"
+            ]
           }
         ]
       }


### PR DESCRIPTION
Follow-up to #164, which shipped the CUDA 13 image. Testing that image on a node changed a decision made in #163.

## The 32 GB variants can run the turbo LoRA

In #163 they shipped without it. Applying a LoRA to fp8 weights makes ComfyUI materialise a dequantized copy of the model, and on the cu128 image that OOM'd during model load on an RTX 5090 at every resolution tested, down to 512x288. ComfyUI's DynamicVRAM manages exactly that kind of load, and the CUDA 13 image from #164 enables it:

| RTX 5090 (32 GB), 1344x768, 124 frames, 4 steps + turbo LoRA | Result |
|---|---|
| cu128 (`2.0.9`) | OOM during model load |
| cu130 (`2.0.10`) | success, 25.5 GB peak, **81 s** |

For comparison, the 8-step no-LoRA path those variants were limited to takes 122 s on the same node and image — so this is both faster and fewer steps.

Changes:

- both 32 GB job definitions download the turbo LoRA matching their task
- `info.json` drops the "no turbo LoRA" qualifier from the 32 GB variants
- the readme documents 4 steps at cfg 1.0 as the turbo path for all variants, and notes that the 32 GB case depends on DynamicVRAM from the CUDA 13 image

## Scope of verification

Both tasks verified on an RTX 5090 with the `2.0.10` image, 1344x768, 124 frames, 4 steps:

| Variant | Peak VRAM | Time |
|---|---|---|
| i2v + `fl2v_turbo_4step_v1.0` | 25.5 GB | 81 s |
| ref2v + `ref2v_turbo_4step_v0.1` | 26.3 GB | 139 s |
