### PR TITLE
fix: align ComfyUI template model resources

### DIFF
--- a/templates/MiniMax-H3/README.md
+++ b/templates/MiniMax-H3/README.md
@@ -10,10 +10,10 @@ the trained range is ~124–362 frames.
 
 | Variant | Task | Text encoder | Requires |
 |---|---|---|---|
-| Image to Video (32 GB) | prompt + optional first/last keyframe | Qwen3-VL 32B nvfp4 | 32 GB, Blackwell |
-| Image to Video (80 GB) | prompt + optional first/last keyframe | Qwen3-VL 32B int8 | 80 GB |
-| Reference to Video (32 GB) | reference images drive identity | Qwen3-VL 32B nvfp4 | 32 GB, Blackwell |
-| Reference to Video (80 GB) | reference images drive identity | Qwen3-VL 32B int8 | 80 GB |
+| Image to Video (32 GB) | prompt + optional first/last keyframe | Official ComfyUI I2V weights | 32 GB, Blackwell |
+| Image to Video (80 GB) | prompt + optional first/last keyframe | Official ComfyUI I2V weights | 80 GB, Blackwell |
+| Reference to Video (32 GB) | reference images drive identity | Official ComfyUI R2V weights | 32 GB, Blackwell |
+| Reference to Video (80 GB) | reference images drive identity | Official ComfyUI R2V weights | 80 GB, Blackwell |
 
 **Image to Video** pins your image as a real frame of the output — first frame,
 optionally last frame, with the model filling in the motion between.
@@ -43,23 +43,19 @@ Both decoders read the same sampled latent — `VAEDecode` takes the video half,
 `VAEDecodeAudio` the audio half. Feed both into `CreateVideo` for a file with
 sound.
 
-All variants ship the matching 4-step turbo LoRA — chain
+All variants ship the task-specific turbo LoRA — chain
 `UNETLoader → LoraLoaderModelOnly → ModelSamplingMiniMaxH3`:
 
 | Setup | steps | cfg |
 |---|---|---|
-| Turbo LoRA | 4 | 1.0 |
-| Without the LoRA | 8 for a quick look, 30 for quality | 1.0 at 8 steps, ~4.0 at 30 |
+| Image-to-video variants with turbo LoRA | 8 | 1.0 |
+| Reference-to-video variants with turbo LoRA | 4 | 1.0 |
 
 cfg above 1.0 evaluates the model twice per step, so steps and cfg together
 drive the run time.
 
 ## Notes
 
-- Applying a LoRA to fp8 weights makes ComfyUI materialise a dequantized copy
-  of the model. This fits a 32 GB card only because the CUDA 13 image enables
-  ComfyUI's DynamicVRAM; on a cu128 image the same graph OOMs during load at
-  any resolution.
 - Keep `UNETLoader` on `weight_dtype: default`; forcing `fp8_e4m3fn` makes the
   quantized kernels reject the weights.
 - `ModelSamplingMiniMaxH3` sets the video and audio flow shifts together
@@ -77,10 +73,9 @@ From [Comfy-Org/MiniMax-H3](https://huggingface.co/Comfy-Org/MiniMax-H3):
 
 | File | Location | Size |
 |---|---|---|
-| `minimax_h3_fl2va_pruned_fp8_scaled.safetensors` (i2v) | `models/diffusion_models/` | 21 GB |
-| `minimax_h3_ref2va_pruned_fp8_scaled.safetensors` (ref2v) | `models/diffusion_models/` | 21 GB |
-| `qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors` (32 GB) | `models/text_encoders/` | 16 GB |
-| `qwen3vl_32b_minimax_h3_int8_convrot.safetensors` (80 GB) | `models/text_encoders/` | 27 GB |
+| `minimax_h3_fl2va_pruned_int8_convrot.safetensors` (i2v) | `models/diffusion_models/` | 21 GB |
+| `minimax_h3_ref2va_pruned_int8_convrot.safetensors` (ref2v) | `models/diffusion_models/` | 21 GB |
+| `qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors` | `models/text_encoders/` | 16 GB |
 | `minimax_h3_video_vae_fp16.safetensors` | `models/vae/` | 5.2 GB |
 | `minimax_h3_audio_vae_fp32.safetensors` | `models/vae/` | 0.6 GB |
-| 4-step turbo LoRA for the matching task | `models/loras/` | 2.0 GB |
+| 8-step I2V / 4-step R2V turbo LoRA | `models/loras/` | 2.0 GB |

--- a/templates/MiniMax-H3/info.json
+++ b/templates/MiniMax-H3/info.json
@@ -12,25 +12,25 @@
     {
       "id": "i2v-32gb",
       "name": "Image to Video (32 GB)",
-      "description": "Keyframe or text to video with audio, fp8 model + nvfp4 encoder (Blackwell), 4-step turbo LoRA",
+      "description": "Official ComfyUI keyframe or text-to-video workflow with audio and 8-step turbo LoRA (Blackwell)",
       "job_definition": "job-definition-i2v-32gb.json"
     },
     {
       "id": "i2v-80gb",
       "name": "Image to Video (80 GB)",
-      "description": "Keyframe or text to video with audio, fp8 model + int8 encoder, 4-step turbo LoRA",
+      "description": "Official ComfyUI keyframe or text-to-video workflow with audio and 8-step turbo LoRA (Blackwell)",
       "job_definition": "job-definition-i2v-80gb.json"
     },
     {
       "id": "ref2v-32gb",
       "name": "Reference to Video (32 GB)",
-      "description": "Reference images drive identity, fp8 model + nvfp4 encoder (Blackwell), 4-step turbo LoRA",
+      "description": "Official ComfyUI reference-to-video workflow with audio and 4-step turbo LoRA (Blackwell)",
       "job_definition": "job-definition-ref2v-32gb.json"
     },
     {
       "id": "ref2v-80gb",
       "name": "Reference to Video (80 GB)",
-      "description": "Reference images drive identity, fp8 model + int8 encoder, 4-step turbo LoRA",
+      "description": "Official ComfyUI reference-to-video workflow with audio and 4-step turbo LoRA (Blackwell)",
       "job_definition": "job-definition-ref2v-80gb.json"
     }
   ]

--- a/templates/MiniMax-H3/job-definition-i2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-32gb.json
@@ -15,7 +15,7 @@
             "target": "/comfyui/models/diffusion_models/",
             "repo": "Comfy-Org/MiniMax-H3",
             "files": [
-              "diffusion_models/minimax_h3_fl2va_pruned_fp8_scaled.safetensors"
+              "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors"
             ]
           },
           {
@@ -38,9 +38,9 @@
           {
             "type": "HF",
             "target": "/comfyui/models/loras/",
-            "repo": "Comfy-Org/MiniMax-H3",
+            "repo": "lightx2v/Minimax-h3-Turbo",
             "files": [
-              "loras/minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors"
+              "minimax_h3_fl2v_turbo_8step_v1.0_comfyui_bf16.safetensors"
             ]
           }
         ]

--- a/templates/MiniMax-H3/job-definition-i2v-80gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-80gb.json
@@ -15,7 +15,7 @@
             "target": "/comfyui/models/diffusion_models/",
             "repo": "Comfy-Org/MiniMax-H3",
             "files": [
-              "diffusion_models/minimax_h3_fl2va_pruned_fp8_scaled.safetensors"
+              "diffusion_models/minimax_h3_fl2va_pruned_int8_convrot.safetensors"
             ]
           },
           {
@@ -23,7 +23,7 @@
             "target": "/comfyui/models/text_encoders/",
             "repo": "Comfy-Org/MiniMax-H3",
             "files": [
-              "text_encoders/qwen3vl_32b_minimax_h3_int8_convrot.safetensors"
+              "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors"
             ]
           },
           {
@@ -38,9 +38,9 @@
           {
             "type": "HF",
             "target": "/comfyui/models/loras/",
-            "repo": "Comfy-Org/MiniMax-H3",
+            "repo": "lightx2v/Minimax-h3-Turbo",
             "files": [
-              "loras/minimax_h3_fl2v_turbo_4step_v1.0_768p_comfyui_bf16.safetensors"
+              "minimax_h3_fl2v_turbo_8step_v1.0_comfyui_bf16.safetensors"
             ]
           }
         ]

--- a/templates/MiniMax-H3/job-definition-ref2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-32gb.json
@@ -15,7 +15,7 @@
             "target": "/comfyui/models/diffusion_models/",
             "repo": "Comfy-Org/MiniMax-H3",
             "files": [
-              "diffusion_models/minimax_h3_ref2va_pruned_fp8_scaled.safetensors"
+              "diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors"
             ]
           },
           {

--- a/templates/MiniMax-H3/job-definition-ref2v-80gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-80gb.json
@@ -15,7 +15,7 @@
             "target": "/comfyui/models/diffusion_models/",
             "repo": "Comfy-Org/MiniMax-H3",
             "files": [
-              "diffusion_models/minimax_h3_ref2va_pruned_fp8_scaled.safetensors"
+              "diffusion_models/minimax_h3_ref2va_pruned_int8_convrot.safetensors"
             ]
           },
           {
@@ -23,7 +23,7 @@
             "target": "/comfyui/models/text_encoders/",
             "repo": "Comfy-Org/MiniMax-H3",
             "files": [
-              "text_encoders/qwen3vl_32b_minimax_h3_int8_convrot.safetensors"
+              "text_encoders/qwen3vl_32b_minimax_h3_nvfp4_awq.safetensors"
             ]
           },
           {


### PR DESCRIPTION
## Summary

- align MiniMax H3 I2V and R2V resources with the filenames embedded in the current official ComfyUI workflows
- add the official I2V 8-step and R2V 4-step turbo LoRAs to all applicable variants
- update MiniMax catalog descriptions and usage documentation

## Verification

- confirmed all declared Hugging Face model objects resolve successfully
- confirmed each MiniMax job definition exactly matches its corresponding official ComfyUI workflow model inventory
- mainnet deployment verification on RTX 5090 and RTX PRO 6000
- `npm test`
- `npm run validate`
- `git diff --check`