### PR TITLE
comfyui: stop 403ing cross-site requests, bump to v0.33.3

### DIFF
--- a/dockerfiles/Dockerfile.comfyui
+++ b/dockerfiles/Dockerfile.comfyui
@@ -6,7 +6,7 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 
 # Pinned so an image tag always maps to one ComfyUI release; model support is
 # tied to the release, e.g. MiniMax Music 3 needs >= 0.33.0.
-ARG COMFYUI_VERSION=v0.33.2
+ARG COMFYUI_VERSION=v0.33.3
 
 # build-essential: triton (via comfy-kitchen) JIT-compiles CUDA driver shims at
 # runtime and fails at import without a C compiler.
@@ -32,4 +32,9 @@ RUN pip install --no-cache-dir --disable-pip-version-check --break-system-packag
 RUN cd custom_nodes && \
     git clone --depth 1 https://github.com/ltdrdata/ComfyUI-Manager.git
 EXPOSE 8188
-CMD ["python", "main.py", "--listen", "0.0.0.0", "--port", "8188"]
+# --enable-cors-header swaps ComfyUI's origin-only middleware for the CORS one.
+# That middleware 403s any request carrying "Sec-Fetch-Site: cross-site"; it
+# guards a loopback ComfyUI against drive-by requests, but this server is
+# reached over a public tunnel, where it only breaks links followed from
+# another site.
+CMD ["python", "main.py", "--listen", "0.0.0.0", "--port", "8188", "--enable-cors-header"]

--- a/templates/ComfyUI/job-definition-flux.json
+++ b/templates/ComfyUI/job-definition-flux.json
@@ -7,7 +7,7 @@
       "id": "Flux-comfy",
       "args": {
         "cmd": [],
-        "image": "docker.io/nosana/comfyui:2.0.5",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "gpu": true,
         "expose": 8188,
         "resources": [

--- a/templates/ComfyUI/job-definition-sd15.json
+++ b/templates/ComfyUI/job-definition-sd15.json
@@ -7,7 +7,7 @@
       "id": "SD15-comfy",
       "args": {
         "cmd": [],
-        "image": "docker.io/nosana/comfyui:2.0.5",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "gpu": true,
         "expose": 8188,
         "resources": [

--- a/templates/ComfyUI/job-definition-sdxl.json
+++ b/templates/ComfyUI/job-definition-sdxl.json
@@ -7,7 +7,7 @@
       "id": "SDXL-comfy",
       "args": {
         "cmd": [],
-        "image": "docker.io/nosana/comfyui:2.0.5",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "gpu": true,
         "expose": 8188,
         "resources": [

--- a/templates/MiniMax-H3/job-definition-i2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-32gb.json
@@ -6,7 +6,7 @@
       "type": "container/run",
       "id": "MiniMaxH3-i2v-comfy",
       "args": {
-        "image": "docker.io/nosana/comfyui:2.0.10",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "expose": 8188,
         "gpu": true,
         "resources": [

--- a/templates/MiniMax-H3/job-definition-i2v-80gb.json
+++ b/templates/MiniMax-H3/job-definition-i2v-80gb.json
@@ -6,7 +6,7 @@
       "type": "container/run",
       "id": "MiniMaxH3-i2v-comfy",
       "args": {
-        "image": "docker.io/nosana/comfyui:2.0.10",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "expose": 8188,
         "gpu": true,
         "resources": [

--- a/templates/MiniMax-H3/job-definition-ref2v-32gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-32gb.json
@@ -6,7 +6,7 @@
       "type": "container/run",
       "id": "MiniMaxH3-ref2v-comfy",
       "args": {
-        "image": "docker.io/nosana/comfyui:2.0.10",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "expose": 8188,
         "gpu": true,
         "resources": [

--- a/templates/MiniMax-H3/job-definition-ref2v-80gb.json
+++ b/templates/MiniMax-H3/job-definition-ref2v-80gb.json
@@ -6,7 +6,7 @@
       "type": "container/run",
       "id": "MiniMaxH3-ref2v-comfy",
       "args": {
-        "image": "docker.io/nosana/comfyui:2.0.10",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "expose": 8188,
         "gpu": true,
         "resources": [

--- a/templates/MiniMax-Music-3/job-definition.json
+++ b/templates/MiniMax-Music-3/job-definition.json
@@ -6,7 +6,7 @@
       "type": "container/run",
       "id": "MiniMaxMusic3-comfy",
       "args": {
-        "image": "docker.io/nosana/comfyui:2.0.9",
+        "image": "docker.io/nosana/comfyui:2.0.11",
         "expose": 8188,
         "gpu": true,
         "resources": [


### PR DESCRIPTION
## Problem

A publicly exposed ComfyUI deployment returns **403 Forbidden** when its service URL is followed as a link from another site (e.g. clicking through from `deploy.nosana.com`), while opening the same URL directly works fine.

The 403 comes from ComfyUI itself — not from FRPS, the tunnel, or any WAF. `server.py:159-165`:

```python
def create_origin_only_middleware():
    @web.middleware
    async def origin_only_middleware(request: web.Request, handler):
        if 'Sec-Fetch-Site' in request.headers:
            sec_fetch_site = request.headers['Sec-Fetch-Site']
            if sec_fetch_site == 'cross-site':
                return web.Response(status=403)
```

Confirmed by probing a live deployment:

| Request | Result |
|---|---|
| plain | 200 |
| `Referer: https://deploy.nosana.com/` | 200 |
| `Origin: https://deploy.nosana.com` | 200 |
| `Sec-Fetch-Mode: navigate` / `Sec-Fetch-Dest: document` | 200 |
| `Sec-Fetch-Site: same-site` / `same-origin` / `none` | 200 |
| **`Sec-Fetch-Site: cross-site`** | **403** |

It is a plain `==` compare, so it is case-sensitive (`CROSS-SITE` passes), and being a middleware it fires before routing — every path 403s, on every method. An unknown tunnel host still returns FRPS's own 503 page even with the header set, which rules out the proxy layers.

## Fix

The middleware's stated purpose is stopping a random website from POSTing workflows to a ComfyUI on `127.0.0.1`. It provides nothing for a deliberately public endpoint: any non-browser client that simply omits the header already gets a 200 on every route. It only breaks legitimate inbound links.

`--enable-cors-header` selects `create_cors_middleware` instead of `create_origin_only_middleware` (they are mutually exclusive, `server.py:236-240`), which removes the check.

## Changes

- `Dockerfile.comfyui`: add `--enable-cors-header` to `CMD`
- `Dockerfile.comfyui`: pin bumped `v0.33.2` → `v0.33.3`
- All 8 ComfyUI-based job definitions → image tag `2.0.11`

## Notes for review

- **v0.33.3 is a tag with no GitHub release attached** — but so was the v0.33.2 already pinned (latest release is v0.33.1). `server.py` is byte-identical between v0.33.2 and v0.33.3. Staying release-only would mean going back to v0.33.1, breaking the `>= 0.33.0` MiniMax Music 3 requirement.
- **The ComfyUI templates jump `2.0.5` → `2.0.11`**, six versions of drift. Bumped so the rebuilt image actually reaches them; revert those three files if they were held back deliberately.
- **`--enable-cors-header` defaults to `*`**, so the image will also emit `Access-Control-Allow-Origin: *`. This does not meaningfully change the security of an unauthenticated public endpoint whose random hostname is already the only secret. If a narrower setting is preferred, `"--enable-cors-header", "https://deploy.nosana.com"` fixes the reported case but leaves other referrers blocked.

## Testing

`npm run validate` passes on all templates.

The image has **not** been built or pushed — `2.0.11` does not exist in the registry yet. This needs `make build-custom REGISTRY=nosana TAG=2.0.11` before merge, otherwise the templates point at a missing tag. Once a node runs it, `curl -o /dev/null -w "%{http_code}" -H "Sec-Fetch-Site: cross-site" <url>` should return 200.