### PR TITLE
Add gateway-only templates for managed vLLM inference

### DIFF
--- a/schemas/schema.js
+++ b/schemas/schema.js
@@ -11,6 +11,7 @@ import { z } from "zod";
 
 // Allowed UI categories for info.json `category`.
 export const CATEGORIES = [
+  "LLM Gateway", // Internal managed inference; never a public or benchmark template.
   "API",
   "Web UI",
   "Featured",
@@ -31,6 +32,16 @@ export const CATEGORIES = [
 // which enforces the no-dots / no-spaces rules — not these catalog ids.
 const catalogId = z.string().min(1);
 
+// Secret-free serving contract. Activation and GPU spending are separately approved.
+export const Inference = z.object({
+  model: z.string().min(1).max(128),
+  context_length: z.number().int().positive(),
+  max_output_tokens: z.number().int().positive(),
+  op: z.string().min(1),
+  port: z.number().int().min(1).max(65535),
+}).strict().refine(v => v.max_output_tokens <= v.context_length,
+  "max_output_tokens must fit context_length");
+
 // A selectable variant shown in the dashboard.
 const Variant = z
   .object({
@@ -38,6 +49,7 @@ const Variant = z
     name: z.string().min(1).max(256),
     description: z.string().optional(),
     job_definition: z.string().min(1),
+    inference: Inference.optional(),
   })
   .strict();
 
@@ -50,5 +62,15 @@ export const Info = z
     category: z.array(z.enum(CATEGORIES)).min(1),
     description: z.string().optional(),
     variants: z.array(Variant).min(1).optional(),
+    inference: Inference.optional(),
   })
-  .strict();
+  .strict().superRefine((info, ctx) => {
+    const internal = info.category.includes("LLM Gateway");
+    const definitions = info.variants ?? [info];
+    if (definitions.some(v => Boolean(v.inference) !== internal)) {
+      ctx.addIssue({ code: "custom", message: "Inference metadata is required only for LLM Gateway definitions" });
+    }
+    if (info.variants && info.inference) {
+      ctx.addIssue({ code: "custom", message: "Put inference metadata on each variant" });
+    }
+  });

--- a/templates/LLM-Gateway-Qwen/9b.json
+++ b/templates/LLM-Gateway-Qwen/9b.json
@@ -1,0 +1,91 @@
+{
+  "version": "0.1",
+  "type": "container",
+  "global": {
+    "variables": {
+      "MAX_MODEL_LEN": "32768",
+      "GPU_MEM_UTIL": "0.90",
+      "MAX_NUM_SEQS": "1024"
+    }
+  },
+  "ops": [
+    {
+      "type": "container/run",
+      "id": "server",
+      "args": {
+        "image": "docker.io/vllm/vllm-openai:v0.26.0",
+        "gpu": true,
+        "entrypoint": [
+          "vllm",
+          "serve"
+        ],
+        "cmd": [
+          "/models/qwen3.5-9b",
+          "--served-model-name",
+          "qwen/qwen3.5-9b",
+          "--host",
+          "0.0.0.0",
+          "--port",
+          "8000",
+          "--max-model-len",
+          "%%global.variables.MAX_MODEL_LEN%%",
+          "--gpu-memory-utilization",
+          "%%global.variables.GPU_MEM_UTIL%%",
+          "--max-num-seqs",
+          "%%global.variables.MAX_NUM_SEQS%%"
+        ],
+        "env": {
+          "VLLM_LOGGING_LEVEL": "INFO",
+          "HF_HUB_OFFLINE": "1"
+        },
+        "restart_policy": {
+          "policy": "on-failure",
+          "restart_tries": 3
+        },
+        "expose": [
+          {
+            "port": 8000,
+            "type": "api",
+            "health_checks": [
+              {
+                "type": "http",
+                "path": "/health",
+                "method": "GET",
+                "expected_status": 200,
+                "continuous": true
+              }
+            ]
+          }
+        ],
+        "resources": [
+          {
+            "type": "HF",
+            "target": "/models/qwen3.5-9b",
+            "repo": "Qwen/Qwen3.5-9B",
+            "files": [
+              "chat_template.jinja",
+              "config.json",
+              "merges.txt",
+              "model.safetensors-00001-of-00004.safetensors",
+              "model.safetensors-00002-of-00004.safetensors",
+              "model.safetensors-00003-of-00004.safetensors",
+              "model.safetensors-00004-of-00004.safetensors",
+              "model.safetensors.index.json",
+              "preprocessor_config.json",
+              "tokenizer.json",
+              "tokenizer_config.json",
+              "video_preprocessor_config.json",
+              "vocab.json"
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "meta": {
+    "trigger": "dashboard",
+    "system_requirements": {
+      "vram_total_mb": 92160
+    }
+  }
+}

--- a/templates/LLM-Gateway-Qwen/README.md
+++ b/templates/LLM-Gateway-Qwen/README.md
@@ -1,0 +1,9 @@
+# Managed Qwen inference
+
+Internal gateway template, based on the benchmarked vLLM Qwen3.5-9B job.
+Client-manager injects the shared `VLLM_API_KEY` and creates a confidential
+INFINITE deployment only after an administrator enables a priced model on an
+approved market. Importing this template does not start a deployment.
+
+The declared 90 GiB VRAM requirement and 32,768 token context reflect the tested
+configuration. Do not lower resource requirements without revalidating the job.

--- a/templates/LLM-Gateway-Qwen/info.json
+++ b/templates/LLM-Gateway-Qwen/info.json
@@ -1,0 +1,24 @@
+{
+  "id": "gateway-qwen",
+  "name": "Managed Qwen inference",
+  "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Qwen_logo.svg/3840px-Qwen_logo.svg.png",
+  "category": [
+    "LLM Gateway",
+    "vLLM",
+    "LLM"
+  ],
+  "variants": [
+    {
+      "id": "9b",
+      "name": "Qwen3.5 9B",
+      "job_definition": "9b.json",
+      "inference": {
+        "model": "qwen/qwen3.5-9b",
+        "context_length": 32768,
+        "max_output_tokens": 8192,
+        "op": "server",
+        "port": 8000
+      }
+    }
+  ]
+}

--- a/tests/schema.validation.test.js
+++ b/tests/schema.validation.test.js
@@ -161,3 +161,11 @@ test("BenchmarksSchema accepts ops_overrides with extra op fields (passthrough)"
   ok[0].ops_overrides.args = { gpu: true };
   assert.equal(BenchmarksSchema.safeParse(ok).success, true);
 });
+
+test("gateway metadata is confined to the reserved category and fits the context", () => {
+  const inference = { model: "qwen/test", context_length: 1024, max_output_tokens: 128, op: "server", port: 8000 };
+  assert.equal(InfoSchema.safeParse({ ...validInfo, inference }).success, false);
+  assert.equal(InfoSchema.safeParse({ ...validInfo, category: ["LLM Gateway"] }).success, false);
+  assert.equal(InfoSchema.safeParse({ ...validInfo, category: ["LLM Gateway"], inference }).success, true);
+  assert.equal(InfoSchema.safeParse({ ...validInfo, category: ["LLM Gateway"], inference: { ...inference, max_output_tokens: 2048 } }).success, false);
+});

--- a/validation/validation.js
+++ b/validation/validation.js
@@ -83,6 +83,7 @@ function validateTemplate(folder) {
   // benchmarks.json is optional; present only for templates with a benchmark.
   const benchmarksPath = path.join(dir, "benchmarks.json");
   if (fs.existsSync(benchmarksPath)) {
+    if (info.category.includes("LLM Gateway")) fail(folder, "LLM Gateway templates cannot contain benchmarks.json");
     validateBenchmarksFile(folder, benchmarksPath, variants.map((variant) => variant.id));
   }
 


### PR DESCRIPTION
Add the reserved `LLM Gateway` category and a dedicated Qwen3.5-9B vLLM variant so client-manager can import a reviewed job definition for managed inference. The metadata declares the served model, context/output limits and exposed operation/port. It contains no credentials or runtime deployment IDs; importing it does not launch GPUs.

Validation requires inference metadata for gateway definitions and rejects gateway templates containing benchmarks.json. The job preserves the tested 90 GiB VRAM and 32,768-token context configuration.

Deploy client-manager's public-template filtering and host-manager's gateway exclusion before merging this template. Provisioning requires the managed-create changes in deployment-manager and explicit model activation in client-manager.

Validation: repository schema tests and all template validation passed; client-manager successfully validated the complete 62-row local catalog including this variant. No GPU workload was launched.
