### PR TITLE
Serve Qwen3.5-4B from the gateway template instead of 9B

### DIFF
--- a/templates/LLM-Gateway-Qwen/4b.json
+++ b/templates/LLM-Gateway-Qwen/4b.json
@@ -3,9 +3,9 @@
   "type": "container",
   "global": {
     "variables": {
-      "MAX_MODEL_LEN": "32768",
-      "GPU_MEM_UTIL": "0.90",
-      "MAX_NUM_SEQS": "1024"
+      "MAX_MODEL_LEN": "16384",
+      "GPU_MEM_UTIL": "0.75",
+      "MAX_NUM_SEQS": "32"
     }
   },
   "ops": [
@@ -20,9 +20,9 @@
           "serve"
         ],
         "cmd": [
-          "/models/qwen3.5-9b",
+          "/models/qwen3.5-4b",
           "--served-model-name",
-          "qwen/qwen3.5-9b",
+          "qwen/qwen3.5-4b",
           "--host",
           "0.0.0.0",
           "--port",
@@ -60,16 +60,14 @@
         "resources": [
           {
             "type": "HF",
-            "target": "/models/qwen3.5-9b",
-            "repo": "Qwen/Qwen3.5-9B",
+            "target": "/models/qwen3.5-4b",
+            "repo": "Qwen/Qwen3.5-4B",
             "files": [
               "chat_template.jinja",
               "config.json",
               "merges.txt",
-              "model.safetensors-00001-of-00004.safetensors",
-              "model.safetensors-00002-of-00004.safetensors",
-              "model.safetensors-00003-of-00004.safetensors",
-              "model.safetensors-00004-of-00004.safetensors",
+              "model.safetensors-00001-of-00002.safetensors",
+              "model.safetensors-00002-of-00002.safetensors",
               "model.safetensors.index.json",
               "preprocessor_config.json",
               "tokenizer.json",
@@ -85,7 +83,7 @@
   "meta": {
     "trigger": "dashboard",
     "system_requirements": {
-      "vram_total_mb": 92160
+      "vram_total_mb": 24576
     }
   }
 }

--- a/templates/LLM-Gateway-Qwen/README.md
+++ b/templates/LLM-Gateway-Qwen/README.md
@@ -1,9 +1,13 @@
 # Managed Qwen inference
 
-Internal gateway template, based on the benchmarked vLLM Qwen3.5-9B job.
-Client-manager injects the shared `VLLM_API_KEY` and creates a confidential
-INFINITE deployment only after an administrator enables a priced model on an
-approved market. Importing this template does not start a deployment.
+Internal gateway template serving Qwen3.5-4B on vLLM. Client-manager injects the
+shared `VLLM_API_KEY` and creates a confidential INFINITE deployment only after
+an administrator enables a priced model on an approved market. Importing this
+template does not start a deployment.
 
-The declared 90 GiB VRAM requirement and 32,768 token context reflect the tested
-configuration. Do not lower resource requirements without revalidating the job.
+Sized for a 24 GB card that is not exclusively ours: vLLM refuses to start when
+free VRAM is below `--gpu-memory-utilization` of the card's total, so the 0.75
+setting leaves room for whatever else holds memory on the node. Within that
+budget the 8.7 GiB of weights and the 2 GiB of KV cache for 16,384 tokens fit
+with headroom. Raising the context or the utilization needs a node with the card
+to itself.

--- a/templates/LLM-Gateway-Qwen/info.json
+++ b/templates/LLM-Gateway-Qwen/info.json
@@ -9,13 +9,13 @@
   ],
   "variants": [
     {
-      "id": "9b",
-      "name": "Qwen3.5 9B",
-      "job_definition": "9b.json",
+      "id": "4b",
+      "name": "Qwen3.5 4B",
+      "job_definition": "4b.json",
       "inference": {
-        "model": "qwen/qwen3.5-9b",
-        "context_length": 32768,
-        "max_output_tokens": 8192,
+        "model": "qwen/qwen3.5-4b",
+        "context_length": 16384,
+        "max_output_tokens": 4096,
         "op": "server",
         "port": 8000
       }


### PR DESCRIPTION
The 9B variant could not start on a 24 GB card. vLLM refuses to boot when free VRAM is below `--gpu-memory-utilization` of the card's total:

```
ValueError: Free memory on device cuda:0 (18.78/23.5 GiB) on startup is less than
desired GPU memory utilization (0.9, 21.15 GiB).
```

That check never looks at the model, so a smaller model at 0.90 fails identically — the utilization has to come down as well. And once it does the 9B no longer fits: a 0.78 budget is 18.33 GiB against 17.98 GiB of weights, leaving nothing for KV cache. Even with the card to itself, 32,768 tokens needs 4 GiB of KV on top of the weights.

Replaced by a 4B variant sized for the same hardware:

| | 9B (before) | 4B (now) |
|---|---|---|
| weights | 17.98 GiB | 8.68 GiB |
| `MAX_MODEL_LEN` | 32768 (4.00 GiB KV) | 16384 (2.00 GiB KV) |
| `GPU_MEM_UTIL` | 0.90 | 0.75 |
| `MAX_NUM_SEQS` | 1024 | 32 |
| `vram_total_mb` | 92160 | 24576 |

Both models have identical KV geometry (32 layers, 4 KV heads, head_dim 256, so 128 KiB/token), which makes the cache figures directly comparable. On a 24 GB card the 4B needs roughly 8.7 + 2.0 + ~1.5 GiB against a 17.6 GiB budget.

`MAX_NUM_SEQS: 1024` was meaningless at either size — the whole KV cache holds about 16k tokens.

The old `vram_total_mb: 92160` was simply wrong: the 9B's weights are 18 GiB, not 90. It is read only for benchmark eligibility rather than for job matching, so it blocked nothing, but it was the figure operators were sizing against.

Verified with client-manager's own `validateJobDefinition` and `validateInferenceDefinition`; both pass, yielding template id `gateway-qwen-4b`.

One note for whoever merges: this removes `gateway-qwen-9b` from the catalog, so an approved model pointing at it is orphaned until client-manager!99 lands, which retires models whose template has left the catalog.
