### PR TITLE
Separate Qwen's reasoning from its reply

### DIFF
--- a/templates/LLM-Gateway-Qwen/4b.json
+++ b/templates/LLM-Gateway-Qwen/4b.json
@@ -32,7 +32,9 @@
           "--gpu-memory-utilization",
           "%%global.variables.GPU_MEM_UTIL%%",
           "--max-num-seqs",
-          "%%global.variables.MAX_NUM_SEQS%%"
+          "%%global.variables.MAX_NUM_SEQS%%",
+          "--reasoning-parser",
+          "qwen3"
         ],
         "env": {
           "VLLM_LOGGING_LEVEL": "INFO",

--- a/templates/LLM-Gateway-Qwen/README.md
+++ b/templates/LLM-Gateway-Qwen/README.md
@@ -11,3 +11,9 @@ setting leaves room for whatever else holds memory on the node. Within that
 budget the 8.7 GiB of weights and the 2 GiB of KV cache for 16,384 tokens fit
 with headroom. Raising the context or the utilization needs a node with the card
 to itself.
+
+The chat template opens the assistant turn with `<think>`, so the model's reply
+begins inside a reasoning block and closes it before the answer. Without a
+reasoning parser that whole block arrives as ordinary message content. `qwen3`
+splits it into `reasoning_content`, and it handles the missing opening tag
+because the template supplies it rather than the model.


### PR DESCRIPTION
A completion came back like this:

```json
"content": "Thinking Process:\n\n1.  **Analyze the Request:** The user is asking me to reply with exactly...",
"reasoning": null
```

The chat template opens the assistant turn with `<think>\n`, so the model's reply begins *inside* a reasoning block and closes it with `</think>` before the answer. With no reasoning parser configured, that whole block is returned as ordinary message content and `reasoning` stays null — a request for a one-line answer arrives with the model's train of thought in front of it.

`--reasoning-parser qwen3` splits on the same `<think>`/`</think>` pair the template uses. Verified against the parser in the running image rather than assumed, since the template's pre-filled opening tag means the output has no opening tag of its own:

| output | reasoning | content |
|---|---|---|
| `Thinking…\n</think>\n\nHello!` (what the template produces) | `Thinking…` | `Hello!` |
| `Thinking…` (truncated before the close) | `Thinking…` | `None` |
| `<think>reasoning</think>Hello!` | `reasoning` | `Hello!` |

The first row is the important one: a parser that required the opening tag would have been a no-op here. `qwen3` is also the only registered parser matching this model, and its `reasoning_start_str`/`reasoning_end_str` are exactly the tokens in this model's `chat_template.jinja`.

Re-validated with client-manager's `validateJobDefinition` and `validateInferenceDefinition`; both still pass.

This does not change how many tokens are generated, only where they are reported. If we also want the default reply to skip thinking entirely, that is a separate one-liner — `--default-chat-template-kwargs '{"enable_thinking": false}'` — which callers could still override per request.
